### PR TITLE
Fix for HF T5Model

### DIFF
--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -301,8 +301,9 @@ class TestIR(unittest.TestCase):
         ec = ExampleCode()
         pipe = Pipe.from_tracing(ec)
         assert 'moved_buffer' in dict(pipe.split_gm.submod_1.named_buffers())
-        # NB: identity comparison
-        assert ec.buffer is pipe.split_gm.submod_1.moved_buffer
+        # NB: identity comparison is not possible because pipe has a deepcopy of the original parameters
+        assert ec.buffer is not pipe.split_gm.submod_1.moved_buffer
+        torch.testing.assert_allclose(ec.buffer, pipe.split_gm.submod_1.moved_buffer)
 
     def test_annotate_split_points_end(self):
         class Foo(torch.nn.Module):


### PR DESCRIPTION
This PR fixes the following issues in IR.py:
1. eliminates dead code in `split.graph`, because a (custom) tracer can produce dead code like orphan get_attr nodes
2. deep clones the module, because further pipe building activities can modify module
3. makes deferral deletion of module attributes because they can be referenced multiple times

All of the aforementioned fixes make HF T5Model work with PiPPy

Fixes #57 #44 

Depends on https://github.com/pytorch/pytorch/pull/74736