### PR TITLE
Fix handling of starred arguments when invoking pipe with kwargs

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -254,7 +254,15 @@ class Pipe(torch.nn.Module):
                     if node.args and len(node.args) > 0:
                         parameters.append(Parameter(node.target, Parameter.POSITIONAL_OR_KEYWORD, default=node.args[0]))
                     else:
-                        parameters.append(Parameter(node.target, Parameter.POSITIONAL_OR_KEYWORD))
+                        parameter_kind = Parameter.POSITIONAL_OR_KEYWORD
+                        param_name = node.target
+                        if node.target.startswith('**'):
+                            parameter_kind = Parameter.VAR_KEYWORD
+                            param_name = param_name[2:]
+                        elif node.target.startswith('*'):
+                            parameter_kind = Parameter.VAR_POSITIONAL
+                            param_name = param_name[1:]
+                        parameters.append(Parameter(param_name, parameter_kind))
             signature = Signature(parameters)
             ba = signature.bind(*args, **kwargs)
             ba.apply_defaults()

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -305,6 +305,24 @@ class TestIR(unittest.TestCase):
         assert ec.buffer is not pipe.split_gm.submod_1.moved_buffer
         torch.testing.assert_allclose(ec.buffer, pipe.split_gm.submod_1.moved_buffer)
 
+    def test_kwarg_invoke_with_double_star(self):
+        class MyModelWithKwarg(torch.nn.Module):
+            def forward(self, x, **kwargs):
+                return torch.relu(x)
+
+        m = MyModelWithKwarg()
+        pipe = Pipe.from_tracing(m)
+
+        x = torch.randn(5, 3)
+        ref_out = m(x)
+        test_out = pipe(x)
+
+        torch.testing.assert_close(test_out, ref_out)
+
+        star_ref_out = m(x=x)
+        star_test_out = pipe(x=x)
+        torch.testing.assert_close(star_test_out, star_ref_out)
+
     def test_annotate_split_points_end(self):
         class Foo(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Previously, if you passed arguments as kwargs and the traced module had `*args` or `**kwargs` in it, invocation would break with the following exception:

```
Traceback (most recent call last):
  File "/pipeline_for_real/test/test_ir.py", line 327, in test_kwarg_invoke_with_double_star
    star_test_out = pipe(x=x)
  File "/pytorch/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/pipeline_for_real/pippy/IR.py", line 262, in forward
    parameters.append(Parameter(node.target, parameter_kind))
  File "/conda/lib/python3.9/inspect.py", line 2551, in __init__
    raise ValueError('{!r} is not a valid parameter name'.format(name))
ValueError: '**kwargs' is not a valid parameter name
```

This changes the code in `Pipe.forward` to properly emit `VAR_POSITIONAL` or `VAR_KEYWORD` arguments when computing the function signature