### PR TITLE
Move _get_value_on_remote as class method

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -151,7 +151,7 @@ class RefcountedFuture:
 def async_transfer(stage_id, microbatch, worker_rref, value_ref_arg, value_ref_executor_rref, arg_idx, runlist_key):
     logging.info(f'[{stage_id}][{microbatch}] Starting transfer')
     self = worker_rref.local_value()
-    fut = value_ref_executor_rref.rpc_async(timeout=0).transfer_value(
+    fut = value_ref_executor_rref.rpc_async(timeout=0).get_value(
         stage_id, runlist_key, microbatch, value_ref_arg)
 
     def bottom_half(fut):
@@ -482,7 +482,7 @@ class PipeStageExecutor:
 
         return ValueReference(self.stage_id, output_unique_key)
 
-    def transfer_value(self, caller_stage, runlist_key, microbatch, value_ref_arg):
+    def get_value(self, caller_stage, runlist_key, microbatch, value_ref_arg):
         callee_stage = value_ref_arg.stage_id
         logging.info(f'[{callee_stage}][{microbatch}] Executing async transfer of value '
                      f'{value_ref_arg} initiated by stage {caller_stage} for {runlist_key}')
@@ -500,18 +500,18 @@ class PipeStageExecutor:
         return value
 
 
-def get_grad_from_executor(executor, qualname):
-    mod = executor.local_value().mod
-    if isinstance(mod, torch.nn.parallel.DistributedDataParallel):
-        mod = mod.module
-    return mod.get_parameter(qualname).grad
+    def get_grad(self, qualname):
+        mod = self.mod
+        if isinstance(mod, torch.nn.parallel.DistributedDataParallel):
+            mod = mod.module
+        return mod.get_parameter(qualname).grad
 
-def set_grad_in_executor(executor, qualname, value):
-    mod = executor.local_value().mod
-    if isinstance(mod, torch.nn.parallel.DistributedDataParallel):
-        mod = mod.module
-    param = mod.get_parameter(qualname)
-    param.grad = value
+    def set_grad(self, qualname, value):
+        mod = self.mod
+        if isinstance(mod, torch.nn.parallel.DistributedDataParallel):
+            mod = mod.module
+        param = mod.get_parameter(qualname)
+        param.grad = value
 
 
 class PipelineDriverBase:
@@ -622,7 +622,7 @@ class PipelineDriverBase:
             for module_name, param_qualname in param_set.items():
                 assert module_name in self.remote_stage_executor_rrefs
                 stage_id, module_rref = self.remote_stage_executor_rrefs[module_name]
-                grad_value = rpc.rpc_sync(module_rref.owner(), get_grad_from_executor, (module_rref, param_qualname))
+                grad_value = module_rref.rpc_sync().get_grad(param_qualname)
                 grad_values.append(grad_value)
 
             synced_value = torch.sum(torch.stack(grad_values), dim=0)
@@ -630,7 +630,7 @@ class PipelineDriverBase:
             for module_name, param_qualname in param_set.items():
                 assert module_name in self.remote_stage_executor_rrefs
                 stage_id, module_rref = self.remote_stage_executor_rrefs[module_name]
-                rpc.rpc_sync(module_rref.owner(), set_grad_in_executor, (module_rref, param_qualname, synced_value))
+                module_rref.rpc_sync().set_grad(param_qualname, synced_value)
 
     def _retrieve_output_values(self, microbatch_interpreters, last_nodes):
         logging.info(f'[root] Retrieving output values from {len(microbatch_interpreters)} chunks')
@@ -643,7 +643,7 @@ class PipelineDriverBase:
         def initiate_async_transfer(a):
             if isinstance(a, ValueReference):
                 value_ref_executor_rref = self.stage_to_executor[a.stage_id]
-                return value_ref_executor_rref.rpc_async(timeout=0).transfer_value(
+                return value_ref_executor_rref.rpc_async(timeout=0).get_value(
                     'root', 'collect', -1, a)
             else:
                 return a


### PR DESCRIPTION
Simplify RPC calls for value transfer by using `rref.rpc_async().class_method()`