### PR TITLE
Comment assert len(output_val) == len(grad_val) which prevents HF models from running

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -46,7 +46,7 @@ def stage_backward(stage_output, output_grads, input_values, stage_info : str):
                 if grad_val is None:
                     return
                 assert isinstance(grad_val, (tuple, list)), f'grad_value expected to have type {type(output_val)} but got {type(grad_val)}'
-                assert len(output_val) == len(grad_val)
+                # assert len(output_val) == len(grad_val) Investigate why it fails! TODO(https://github.com/pytorch/PiPPy/issues/135)
                 for ov, gv in zip(output_val, grad_val):
                     extract_tensors_with_grads(ov, gv)
             elif isinstance(output_val, dict):


### PR DESCRIPTION
https://github.com/pytorch/PiPPy/pull/130 fails without this change with:
```
Running BERT pipeline.
Exception in thread worker_6:
Traceback (most recent call last):
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 63, in stage_backward
    extract_tensors_with_grads(stage_output, output_grads)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 49, in extract_tensors_with_grads
    assert len(output_val) == len(grad_val)
AssertionError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/pbelevich/miniconda3/envs/PiPPy/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/Users/pbelevich/miniconda3/envs/PiPPy/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/PipelineDriver.py", line 361, in worker_loop
    out_val = stage_backward(*args, **kwargs)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 81, in stage_backward
    raise RuntimeError(exc_msg) from e
RuntimeError: 
        Failed to run backward stage stage_backward for stage %submod_5 : [#users=2] = call_module[target=submod_5](args = (%submod_4, %getitem_1, %labels), kwargs = {})
        Stage output value: ('Tensor(size=torch.Size([]))', 'Tensor(size=torch.Size([24, 32, 30522]))')
        Output gradient values: ('None',)
        Input values: ['Tensor(size=torch.Size([24, 32, 768]))', 'Tensor(size=torch.Size([24, 1, 32, 32]))', 'Tensor(size=torch.Size([24, 32]))']
        
```

https://github.com/pytorch/PiPPy/pull/131 fails without this change with:
```
Running GPT2 pipeline.
Exception in thread worker_6:
Traceback (most recent call last):
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 63, in stage_backward
    extract_tensors_with_grads(stage_output, output_grads)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 49, in extract_tensors_with_grads
    assert len(output_val) == len(grad_val)
AssertionError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/pbelevich/miniconda3/envs/PiPPy/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/Users/pbelevich/miniconda3/envs/PiPPy/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/PipelineDriver.py", line 361, in worker_loop
    out_val = stage_backward(*args, **kwargs)
  File "/Users/pbelevich/PycharmProjects/PiPPy/pippy/IR.py", line 81, in stage_backward
    raise RuntimeError(exc_msg) from e
RuntimeError: 
        Failed to run backward stage stage_backward for stage %submod_5 : [#users=6] = call_module[target=submod_5](args = (%getitem_21, %getitem_1, %labels), kwargs = {})
        Stage output value: ('Tensor(size=torch.Size([]))', 'Tensor(size=torch.Size([24, 32, 50257]))', 'Tensor(size=torch.Size([24, 12, 32, 64]))', 'Tensor(size=torch.Size([24, 12, 32, 64]))', 'Tensor(size=torch.Size([24, 12, 32, 64]))', 'Tensor(size=torch.Size([24, 12, 32, 64]))')
        Output gradient values: ('None',)
        Input values: ['Tensor(size=torch.Size([24, 32, 768]))', 'Tensor(size=torch.Size([24, 32]))']
```