### PR TITLE
Fix case where not all outputs of a stage have grads

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -49,7 +49,7 @@ def stage_backward(stage_output, output_grads, input_values, stage_info : str, o
                 if grad_val is None:
                     return
                 assert isinstance(grad_val, (tuple, list)), f'grad_value expected to have type {type(output_val)} but got {type(grad_val)}'
-                # assert len(output_val) == len(grad_val) Investigate why it fails! TODO(https://github.com/pytorch/PiPPy/issues/135)
+                assert len(output_val) == len(grad_val)
                 for ov, gv in zip(output_val, grad_val):
                     extract_tensors_with_grads(ov, gv)
             elif isinstance(output_val, dict):


### PR DESCRIPTION
Resolves https://github.com/pytorch/PiPPy/issues/135

If the loss is not the only value being returned, the last stage of the forward will have multiple outputs but gradient signal (actually `None`) for only the loss value and nothing else. Previously, we were emitting the graph s.t. the backward stage for the last stage only had `stage_output` and `grad_output` for the loss value. However, this was incompatible with how we were doing `fwd_cache`. So now, I'm emitting the loss stage with all the outputs/grads, and passing in an argument to specify which outputs are expected to have grad signal.

Note that I initially tried to fix this by killing `fwd_cache` but ran into [complications](https://github.com/pytorch/PiPPy/issues/121#issuecomment-1104477624)

Confirmed to fix #130 and #131