### PR TITLE
Add deep_copy_module option to Pipe.from_tracing

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -739,7 +739,7 @@ class Pipe(torch.nn.Module):
 
     @staticmethod
     def from_tracing(mod : torch.nn.Module, multi_use_param_spec : Optional[MultiUseParamSpec] = None,
-                     tracer=None, output_loss_value_spec=None, **kwargs):
+                     tracer=None, output_loss_value_spec=None, deep_copy_module=False, **kwargs):
         # TODO: abstract partitioning policy
 
         global _pipeline_tracer
@@ -747,7 +747,8 @@ class Pipe(torch.nn.Module):
         _pipeline_tracer = tracer or torch.fx.Tracer()
         try:
             # TODO: tracing policy
-            mod = copy.deepcopy(mod)  # because further pipe building activities can modify mod
+            if deep_copy_module:
+                mod = copy.deepcopy(mod)  # because further pipe building activities can modify mod
             graph = _pipeline_tracer.trace(mod, **kwargs)
             traced = torch.fx.GraphModule(mod, graph)
         finally:

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -342,7 +342,14 @@ class TestIR(unittest.TestCase):
 
     def test_from_tracing_preserves_buffer(self):
         ec = ExampleCode()
-        pipe = Pipe.from_tracing(ec)
+
+        pipe = Pipe.from_tracing(ec, deep_copy_module=False)
+        assert 'moved_buffer' in dict(pipe.split_gm.submod_1.named_buffers())
+        # NB: identity comparison
+        assert ec.buffer is pipe.split_gm.submod_1.moved_buffer
+        torch.testing.assert_allclose(ec.buffer, pipe.split_gm.submod_1.moved_buffer)
+
+        pipe = Pipe.from_tracing(ec, deep_copy_module=True)
         assert 'moved_buffer' in dict(pipe.split_gm.submod_1.named_buffers())
         # NB: identity comparison is not possible because pipe has a deepcopy of the original parameters
         assert ec.buffer is not pipe.split_gm.submod_1.moved_buffer


### PR DESCRIPTION
Don't deep copy module by default to save memory. This means that `Pipe.from_tracing` may corrupt original module. Pass `deep_copy_module=True` to preserve original module