### PR TITLE
Switch sync_barrier to run on stage 0's executor

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -768,10 +768,8 @@ class RemoteInterpreter(torch.fx.Interpreter, EventRecorder):
                 invocation_key, Phase.BACKWARD, args, kwargs, self.cur_microbatch, debug_str=node.format_node(),
                 output_refcount=len(node.users), batch_id=self.batch_id, num_microbatches=self.num_microbatches)
         elif target is sync_barrier:
-            # TODO: just assuming the last executor is indeed the executor for the
-            # last stage. We should do this in a more principled way
             executor_keys = list(self.remote_stage_executor_rrefs.keys())
-            stage_id, stage_executor = self.remote_stage_executor_rrefs[executor_keys[-1]]
+            stage_id, stage_executor = self.remote_stage_executor_rrefs[executor_keys[0]]
             logging.info(f'[root][{self.cur_microbatch}] Issuing sync invocation '
                          f'on stage {stage_id}')
             return stage_executor.rpc_sync().invoke(


### PR DESCRIPTION

Before:

![image](https://user-images.githubusercontent.com/4685384/164775386-3bf0fe89-114d-46fa-a5ba-68783ff5032d.png)


After:

![image](https://user-images.githubusercontent.com/4685384/164775364-ced089c2-1fc3-41cb-856a-41a862ff3ed4.png)
