### PR TITLE
Add pippy_wrapper to test folder

### DIFF
--- a/test/pippy_wrapper.sh
+++ b/test/pippy_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+export MASTER_PORT=29500
+export MASTER_ADDR=$(scontrol show hostname ${SLURM_NODELIST} | head -n 1)
+export LOCAL_RANK=${SLURM_LOCALID}
+# Optional: depending on whether the application wants each procoess to see only 1 GPU or all GPUs
+#export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
+export WORLD_SIZE=${SLURM_NTASKS}
+export RANK=${SLURM_PROCID}
+
+exec "$@"


### PR DESCRIPTION
Workaround for Issue #166.

Usage example:
```
srun -N1 -p train --gpus-per-node=8 --ntasks-per-node=14 ./pippy_wrapper.sh python local_test_forward_hf_gpt2.py
```