### PR TITLE
Add optimizer integration

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, List, Tuple, Optional
 import torch
 import torch.distributed.rpc as rpc
 import torch.fx
-from torch.distributed.rpc import RRef
 
 from pippy.IR import Pipe, stage_backward, sync_barrier, _null_coalesce_accumulate
 from pippy.events import EventRecorder, EventsContext, Event


### PR DESCRIPTION
Stacked on https://github.com/pytorch/PiPPy/pull/163

This implements rudimentary optimizer support. Previously, we thought that we could use DistributedOptimizer, however that depends on accounting for gradients in a distributed autograd context. Instead, we add an API `instantiate_optimizer` that instantiates the given optimizer class on the remote for each pipeline stage. This API returns a `PipelineOptimizer`, which exposes `zero_grad` and `step` APIs that internally make RPCs to the optimizers on each pipeline stage and calls the respective methods

Hitting 0.91 accuracy after 1 epoch on the MNIST example:

Pipelining:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/4685384/165212172-b5231ce9-48e6-48bb-ae82-7d5d659a476a.png">

Baseline:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/4685384/165212206-ab1a30bf-c95c-49a9-b2d9-ae974d6d9285.png">
