### PR TITLE
Switch pipe stages to direct serialization

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -387,8 +387,9 @@ def _direct_serialization_deserialize(body, nodes):
 
     graph = torch.fx.Graph()
 
+    env = {}
     for node in nodes:
-        graph.node_copy(node)
+        env[node] = graph.node_copy(node, lambda n: env[n])
 
     dummy = DummyModule(body)
 

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -382,18 +382,21 @@ def _direct_serialization_deserialize(body, nodes):
     """
     class DummyModule(torch.nn.Module):
         def __init__(self, body):
-            self.__dict__ = body
+            super().__init__()
+            self.__dict__.update(body)
 
     graph = torch.fx.Graph()
 
     for node in nodes:
         graph.node_copy(node)
 
-    return torch.fx.GraphModule(DummyModule(body), graph)
+    dummy = DummyModule(body)
+
+    return torch.fx.GraphModule(dummy, graph)
 
 
 def _direct_serialization_reduce(self):
-    return (_direct_serialization_deserialize, (self.__dict__, list(self.graph.nodes)))
+    return (_direct_serialization_deserialize, (dict(self.__dict__), list(self.graph.nodes)))
 
 
 class Pipe(torch.nn.Module):

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -276,8 +276,12 @@ class TestIR(unittest.TestCase):
                 return rv
 
         class FooMod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn(1))
+
             def forward(self, x):
-                return x + arange_wrapper(x.shape[-1])
+                return x + arange_wrapper(x.shape[-1]) + 1 + torch.zeros(1)
 
         fm = FooMod()
 

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -284,14 +284,15 @@ class TestIR(unittest.TestCase):
         tracer = CustomTracer()
         pipe = Pipe.from_tracing(fm, tracer=tracer)
 
-        print(type(pipe.split_gm.submod_0))
-
         with tempfile.TemporaryDirectory() as d:
             with open(d + 'tmp.pkl', 'wb') as f:
                 pickle.dump(pipe.split_gm.submod_0, f)
 
             with open(d + 'tmp.pkl', 'rb') as f:
                 loaded = pickle.load(f)
+
+        x = torch.randn(5, 3)
+        torch.testing.assert_close(pipe.split_gm.submod_0(x), loaded(x))
 
     def test_deeply_nested_parameter(self):
         class Nest(torch.nn.Module):

--- a/test/test_ir.py
+++ b/test/test_ir.py
@@ -1,11 +1,19 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import torch
 import copy
+import pickle
+import tempfile
+import torch
 import unittest
 from typing import NamedTuple
 
 from pippy.IR import Pipe, PipeSequential, TrivialLossWrapper, pipe_split, MultiUseParameterConfig, annotate_split_points, PipeSplitWrapper, _null_coalesce_accumulate
 from pippy.microbatch import TensorChunkSpec, split_args_kwargs_into_chunks, merge_chunks
+
+import torch.fx
+
+@torch.fx.wrap
+def arange_wrapper(*args, **kwargs):
+    return torch.arange(*args, **kwargs)
 
 class ExampleCode(torch.nn.Module):
     def __init__(self):
@@ -256,6 +264,34 @@ class TestIR(unittest.TestCase):
             k_ref = pipe.remap_qualname(k_test)
             v_ref = ref_grads[k_ref]
             torch.testing.assert_allclose(v_test, v_ref)
+
+    def test_custom_tracer_serialization(self):
+        class CustomTracer(torch.fx.Tracer):
+            def trace(self, root, concrete_args=None):
+                rv = super().trace(root, concrete_args)
+                for node in rv.nodes:
+                    if node.target == arange_wrapper:
+                        node.target = torch.arange
+                        node.meta.clear()
+                return rv
+
+        class FooMod(torch.nn.Module):
+            def forward(self, x):
+                return x + arange_wrapper(x.shape[-1])
+
+        fm = FooMod()
+
+        tracer = CustomTracer()
+        pipe = Pipe.from_tracing(fm, tracer=tracer)
+
+        print(type(pipe.split_gm.submod_0))
+
+        with tempfile.TemporaryDirectory() as d:
+            with open(d + 'tmp.pkl', 'wb') as f:
+                pickle.dump(pipe.split_gm.submod_0, f)
+
+            with open(d + 'tmp.pkl', 'rb') as f:
+                loaded = pickle.load(f)
 
     def test_deeply_nested_parameter(self):
         class Nest(torch.nn.Module):


### PR DESCRIPTION
This PR switches switches pipeline stages to use a serialization technique I'm calling "direct serialization". Instead of persisting generated code and re-tracing that code on the load path, we directly serialize the Graph data structure. We are doing this because it is not guaranteed that the semantics of a custom tracer will work for deserializing subsets of a GraphModule generated with that tracer.

Note that this is *NOT* a generalizable technique and should *NOT* be used in any place where the serialized artifact becomes as BC/FC surface.