### PR TITLE
Double pipe scheme

### DIFF
--- a/examples/slurm/hf/t5/pippy_sbatch_8_gpus_per_node.sh
+++ b/examples/slurm/hf/t5/pippy_sbatch_8_gpus_per_node.sh
@@ -17,4 +17,10 @@
 
 #SBATCH --time=1:00:00
 
+# Use the following settings instead if using double pipes
+# as it uses 2x number of processes
+##SBATCH --ntasks-per-node=16
+##SBATCH --cpus-per-task=6
+##SBATCH -m plane=8
+
 srun --label pippy_wrapper.sh

--- a/examples/slurm/hf/t5/pippy_t5.py
+++ b/examples/slurm/hf/t5/pippy_t5.py
@@ -275,12 +275,12 @@ if __name__ == "__main__":
     parser.add_argument('--visualize', type=int, default=1, choices=[0, 1])
     parser.add_argument('--record_mem_dumps', type=int, default=0, choices=[0, 1])
     parser.add_argument('--checkpoint', type=int, default=1, choices=[0, 1])
-    parser.add_argument('--dp_group_size', type=int, default=8)
+    parser.add_argument('--pp_group_size', type=int, default=8)
     args = parser.parse_args()
 
-    assert args.world_size % args.dp_group_size == 0
+    assert args.world_size % args.pp_group_size == 0
 
-    args.pp_group_size = args.world_size // args.dp_group_size
+    args.dp_group_size = args.world_size // args.pp_group_size
 
     if args.rank == -1:
         mp.spawn(run_worker, args=(args.world_size, args,), nprocs=args.world_size, join=True)

--- a/examples/slurm/hf/t5/pippy_wrapper.sh
+++ b/examples/slurm/hf/t5/pippy_wrapper.sh
@@ -4,11 +4,17 @@
 export MASTER_PORT=29500
 export MASTER_ADDR=$(scontrol show hostname ${SLURM_NODELIST} | head -n 1)
 export LOCAL_RANK=${SLURM_LOCALID}
-export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
 export WORLD_SIZE=${SLURM_NTASKS}
 export RANK=${SLURM_PROCID}
+
+# Use modulo to cover both regular-pipe and double-pipe cases
+# Double pipe can use 2x processes than the number of GPUs
+export CUDA_VISIBLE_DEVICES=$(( SLURM_LOCALID % SLURM_GPUS_PER_NODE ))
 
 python -u pippy_t5.py \
   --model_config=t5_3b_config.json \
   --record_mem_dumps=0 \
   --checkpoint=1
+# Additional options for double pipes
+#  --double_pipe=1 \
+#  --pp_group_size=$(( SLURM_JOB_NUM_NODES * 2 ))


### PR DESCRIPTION
### Double Pipe Scheme:
- Add a conjugate pipe that pushes chunks in a reverse direction than the original pipe
- The conjugate pipe will fill the computation utilization blanks of the original pipe
- The conjugate pipe will also utilize the communication bandwidth in the reverse direction

![Double_Pipe_Scheme](https://user-images.githubusercontent.com/6676466/178349244-c414c73c-55f2-473a-ab0d-5c21d51dd5b7.png)

### Implementation:
- Corresponding stages on the original pipe and conjugate pipe synchronize gradients using DDP
- To improve performance of this DDP sync, we arrange each pipe in a loopback shape in the node dimension
![Double_Pipe_Rank_Arrangement](https://user-images.githubusercontent.com/6676466/178350727-7ea3a959-dc80-44a6-8a44-92d52d058f36.png)

