### PR TITLE
[SPMD] Enable black lint for code in `spmd`

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,3 +33,5 @@ jobs:
       run: mypy $(git ls-files '*.py')
     - name: Lint with flake8
       run: flake8 pippy
+    - name: Lint with black for SPMD
+      run: black --line-length 80 spmd test/spmd

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Lint with flake8
       run: flake8 pippy
     - name: Lint with black for SPMD
-      run: black --line-length 80 spmd test/spmd
+      run: black --check --line-length 80 spmd test/spmd

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -2,13 +2,7 @@
 from typing import List
 import torch
 import torch.nn as nn
-from spmd.tensor import (
-    Tensor,
-    Placement,
-    Shard,
-    Replicate,
-    _Partial
-)
+from spmd.tensor import Tensor, Placement, Shard, Replicate, _Partial
 from spmd.tensor.device_mesh import (
     get_global_device_mesh,
     DeviceMesh,
@@ -17,9 +11,15 @@ from spmd.tensor.device_mesh import (
 torch.__future__.set_overwrite_module_params_on_conversion(True)
 
 
-def distribute_tensor(tensor: torch.Tensor, device_mesh: DeviceMesh = None, placements: List[Placement] = None):
+def distribute_tensor(
+    tensor: torch.Tensor,
+    device_mesh: DeviceMesh = None,
+    placements: List[Placement] = None,
+):
     # get default device mesh if there's nothing specified
-    device_mesh = get_global_device_mesh() if device_mesh is None else device_mesh
+    device_mesh = (
+        get_global_device_mesh() if device_mesh is None else device_mesh
+    )
     # convert tensor to the correponding device type if it's not in that device type
     tensor = tensor.to(device_mesh.device_type)
     # set default placements to replicated if not specified
@@ -31,17 +31,25 @@ def distribute_tensor(tensor: torch.Tensor, device_mesh: DeviceMesh = None, plac
     for idx, placement in enumerate(placements):
         if isinstance(placement, Shard):
             shard_dim = placement.dim
-            assert shard_dim <= tensor.ndim, "Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim}"
+            assert (
+                shard_dim <= tensor.ndim
+            ), "Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim}"
             # TODO: handle multi-dim device mesh and last shard
             num_chunks = device_mesh.size()
-            assert tensor.size(shard_dim) % num_chunks == 0, "Only support chunk sharding evenly now"
+            assert (
+                tensor.size(shard_dim) % num_chunks == 0
+            ), "Only support chunk sharding evenly now"
             chunk_size = tensor.size(shard_dim) // num_chunks
             tensor_list = list(tensor.chunk(num_chunks, dim=shard_dim))
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
             local_tensor = device_mesh.scatter(tensor_list)
-            dist_tensor = Tensor.from_local(local_tensor, device_mesh, placements)
-        elif isinstance(placement, Replicate) or isinstance(placement, _Partial):
+            dist_tensor = Tensor.from_local(
+                local_tensor, device_mesh, placements
+            )
+        elif isinstance(placement, Replicate) or isinstance(
+            placement, _Partial
+        ):
             dist_tensor = Tensor.from_local(tensor, device_mesh, placements)
         else:
             raise RuntimeError("Not supported!")
@@ -49,14 +57,17 @@ def distribute_tensor(tensor: torch.Tensor, device_mesh: DeviceMesh = None, plac
     return dist_tensor
 
 
-def distribute_module(mod: nn.Module, device_mesh: DeviceMesh = None, spec: List[Placement] = None):
-    '''
+def distribute_module(
+    mod: nn.Module, device_mesh: DeviceMesh = None, spec: List[Placement] = None
+):
+    """
     this function coverts all module parameters
     to distributed tensor parameters according to
     the placements and device_mesh spcified.
     TODO: add a more flexible tagging, i.e. convert
     certain param to a certain spec, like a PlacementPlan
-    '''
+    """
+
     def to_dist_tensor(t):
         if isinstance(t, nn.Parameter):
             return distribute_tensor(t.data, device_mesh, spec)

--- a/spmd/tensor/__init__.py
+++ b/spmd/tensor/__init__.py
@@ -1,12 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from spmd.tensor.api import Tensor
 from spmd.tensor.device_mesh import DeviceMesh
-from spmd.tensor.placement_types import (
-    Placement,
-    Shard,
-    Replicate,
-    _Partial
-)
+from spmd.tensor.placement_types import Placement, Shard, Replicate, _Partial
 
 # Import all builtin dist tensor ops
 import spmd.tensor.ops

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -3,20 +3,12 @@ import copy
 import torch
 from torch.utils._pytree import tree_map
 from typing import Dict, List, Callable, Optional
-from spmd.tensor.device_mesh import (
-    get_global_device_mesh,
-    DeviceMesh
-)
-from spmd.tensor.placement_types import (
-    Placement,
-    Shard,
-    Replicate,
-    _Partial
-)
+from spmd.tensor.device_mesh import get_global_device_mesh, DeviceMesh
+from spmd.tensor.placement_types import Placement, Shard, Replicate, _Partial
 
 
 class Tensor(torch.Tensor):
-    __slots__ = ['_local_tensor', '_device_mesh', '_placements']
+    __slots__ = ["_local_tensor", "_device_mesh", "_placements"]
 
     # class attribute that handles ops, all handled
     # ops should appear in this table
@@ -27,17 +19,23 @@ class Tensor(torch.Tensor):
     __torch_function__ = torch._C._disabled_torch_function_impl
 
     @staticmethod
-    def __new__(cls, device_mesh: DeviceMesh, placements: List[Placement], size: torch.Size, **kwargs):
+    def __new__(
+        cls,
+        device_mesh: DeviceMesh,
+        placements: List[Placement],
+        size: torch.Size,
+        **kwargs,
+    ):
         # new method instruct wrapper tensor and add placement spec
         # it does not do actual distribution, __init__ should do it instead.
         # TODO: implement __init__ for tensor constructors
         assert isinstance(placements, list)
         assert len(placements) == 1, "Only support 1-d placement for now"
         # sizes = _flatten_tensor_size(size)
-        dtype = kwargs['dtype']
-        layout = kwargs['layout']
-        requires_grad = kwargs['requires_grad']
-        device = kwargs.get('device', 'cpu')
+        dtype = kwargs["dtype"]
+        layout = kwargs["layout"]
+        requires_grad = kwargs["requires_grad"]
+        device = kwargs.get("device", "cpu")
 
         r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
             cls,
@@ -45,7 +43,7 @@ class Tensor(torch.Tensor):
             dtype=dtype,
             device=device,
             layout=layout,
-            requires_grad=requires_grad
+            requires_grad=requires_grad,
         )
         r._device_mesh = device_mesh
         # deepcopy and set spec, data should be handled
@@ -59,7 +57,6 @@ class Tensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-
         def unwrap_mesh(e):
             # if this tensor is not Distributed, then return none. We will reinterpret it as replicated
             if not isinstance(e, Tensor):
@@ -70,7 +67,11 @@ class Tensor(torch.Tensor):
             return e._local_tensor if isinstance(e, Tensor) else e
 
         def wrap(e, mesh, placements):
-            return Tensor.from_local(e, mesh, placements, run_check=False) if isinstance(e, torch.Tensor) else e
+            return (
+                Tensor.from_local(e, mesh, placements, run_check=False)
+                if isinstance(e, torch.Tensor)
+                else e
+            )
 
         args_mesh = tree_map(unwrap_mesh, args)
         # assert all_equal(spec.device_mesh for spec in args_spec), "can't compuate across different meshes"
@@ -81,7 +82,7 @@ class Tensor(torch.Tensor):
         all_replicated = True
         for arg in args:
             if isinstance(arg, Tensor):
-                all_replicated &= (arg.placements[0] == Replicate())
+                all_replicated &= arg.placements[0] == Replicate()
 
         if all_replicated:
             rs = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
@@ -98,12 +99,16 @@ class Tensor(torch.Tensor):
             return rs
 
     @classmethod
-    def from_local(cls, local_tensor, device_mesh=None, placements=None, run_check=True):
+    def from_local(
+        cls, local_tensor, device_mesh=None, placements=None, run_check=True
+    ):
         # if same shape/dtype, no need to run_check, if not, must allgather
         # the metadatas to check the size/dtype across ranks
         # There should be no data communication unless there's replication
         # strategy, where we broadcast the replication from rank 0
-        device_mesh = get_global_device_mesh() if device_mesh is None else device_mesh
+        device_mesh = (
+            get_global_device_mesh() if device_mesh is None else device_mesh
+        )
         # convert the local tensor to desired device base on device mesh's device_type
         local_tensor = local_tensor.to(device_mesh.device_type)
 
@@ -117,7 +122,9 @@ class Tensor(torch.Tensor):
             if isinstance(placement, Shard):
                 shard_dim = placement.dim
                 # recover tensor shape on the shard dim
-                tensor_shape[shard_dim] = tensor_shape[shard_dim] * device_mesh.size(idx)
+                tensor_shape[shard_dim] = tensor_shape[
+                    shard_dim
+                ] * device_mesh.size(idx)
             elif isinstance(placement, Replicate):
                 # broadcast rank 0 tensor to all ranks
                 local_tensor = local_tensor.contiguous()
@@ -126,7 +133,9 @@ class Tensor(torch.Tensor):
                 # we don't need to do anything to Partial case
                 pass
             else:
-                raise RuntimeError(f"placement type {type(placement)} not supported!")
+                raise RuntimeError(
+                    f"placement type {type(placement)} not supported!"
+                )
 
         if run_check:
             # TODO: by default check tensor metas across rank
@@ -139,49 +148,67 @@ class Tensor(torch.Tensor):
             dtype=local_tensor.dtype,
             device=local_tensor.device,
             layout=local_tensor.layout,
-            requires_grad=local_tensor.requires_grad
+            requires_grad=local_tensor.requires_grad,
         )
         dist_tensor._local_tensor = local_tensor
         return dist_tensor
 
-    def redistribute(self, device_mesh: Optional[DeviceMesh] = None, placements: Optional[List[Placement]] = None) -> "Tensor":
+    def redistribute(
+        self,
+        device_mesh: Optional[DeviceMesh] = None,
+        placements: Optional[List[Placement]] = None,
+    ) -> "Tensor":
         # This API perform necessary transformations and get
         # a new DistributedTensor with the new spec. i.e. for
         # sharding it's a reshard behavior.
         # TODO: handle last shard uneven with padding
         # right now we assume all local shard equal size
-        device_mesh = get_global_device_mesh() if device_mesh is None else device_mesh
+        device_mesh = (
+            get_global_device_mesh() if device_mesh is None else device_mesh
+        )
         # raise error if new placements not specified
         if placements is None:
             raise RuntimeError("placements is needed for redistribute!")
 
         current_placements = self.placements
         assert len(placements) == 1, "Only support 1-d placement for now"
-        assert self.device_mesh.mesh.equal(device_mesh.mesh), "cross mesh comm not support yet"
+        assert self.device_mesh.mesh.equal(
+            device_mesh.mesh
+        ), "cross mesh comm not support yet"
         local_tensor = self.local_tensor()
-        if isinstance(current_placements[0], Shard) and isinstance(placements[0], Replicate):
+        if isinstance(current_placements[0], Shard) and isinstance(
+            placements[0], Replicate
+        ):
             # for shard, all_gather all shards and return the global tensor
             global_tensor = torch.empty(
-                *self.size(),
-                device=local_tensor.device,
-                dtype=self.dtype
+                *self.size(), device=local_tensor.device, dtype=self.dtype
             )
             # NOTE: all_gather_base only works well when tensor
             # sharded on a sequential list of devices
             device_mesh.all_gather_base(global_tensor, local_tensor)
-            replica_tensor = Tensor.from_local(global_tensor, device_mesh, placements)
+            replica_tensor = Tensor.from_local(
+                global_tensor, device_mesh, placements
+            )
             replica_tensor._placements[0] = Replicate()
             return replica_tensor
-        elif isinstance(current_placements[0], _Partial) and isinstance(placements[0], Replicate):
-            reduced_tensor = device_mesh.all_reduce(local_tensor, current_placements[0].reduce_op)
-            replica_tensor = Tensor.from_local(reduced_tensor, device_mesh, current_placements)
+        elif isinstance(current_placements[0], _Partial) and isinstance(
+            placements[0], Replicate
+        ):
+            reduced_tensor = device_mesh.all_reduce(
+                local_tensor, current_placements[0].reduce_op
+            )
+            replica_tensor = Tensor.from_local(
+                reduced_tensor, device_mesh, current_placements
+            )
             # change placement to replicate
             replica_tensor._placements[0] = Replicate()
             return replica_tensor
         elif current_placements == placements:
             return self
         else:
-            raise RuntimeError(f"Converting from {current_placements} to {placements} not supported!")
+            raise RuntimeError(
+                f"Converting from {current_placements} to {placements} not supported!"
+            )
 
     def local_tensor(self) -> torch.Tensor:
         return self._local_tensor  # type: ignore

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -3,7 +3,7 @@ import torch
 from torch.distributed.distributed_c10d import (
     get_rank,
     ReduceOp,
-    _get_default_group
+    _get_default_group,
 )
 
 # autograd enabled collective
@@ -12,7 +12,7 @@ from torch.distributed.nn.functional import (
     _all_gather_base,
     all_reduce,
     broadcast,
-    scatter
+    scatter,
 )
 
 _global_device_mesh = None
@@ -29,7 +29,7 @@ def set_global_device_mesh(mesh):
 
 
 class DeviceMesh(object):
-    '''
+    """
     Device Mesh object, can be used as a context manager.
     By default describes the device ids, layout and serves
     as a proxy for communication among the device lists.
@@ -39,7 +39,8 @@ class DeviceMesh(object):
     add collective wrappers in this class. This is used to
     decouple detailed communication backend with the underlying
     DistributedTensor implementation.
-    '''
+    """
+
     device_type: str
     mesh: torch.Tensor
     # _world_pg: ProcessGroup
@@ -51,11 +52,15 @@ class DeviceMesh(object):
         default_pg = _get_default_group()
         backend_name = default_pg._get_backend_name()
         if device_type == "cpu":
-            assert backend_name == "gloo", f"ProcessGroup backend: {backend_name} not supporting CPU!"
+            assert (
+                backend_name == "gloo"
+            ), f"ProcessGroup backend: {backend_name} not supporting CPU!"
         elif device_type == "cuda":
             assert backend_name == "gloo" or backend_name == "nccl"
         else:
-            raise RuntimeError(f"DeviceMesh only support cpu or cuda device type, but got {device_type}")
+            raise RuntimeError(
+                f"DeviceMesh only support cpu or cuda device type, but got {device_type}"
+            )
 
         # TODO: support multi-dimensional device mesh
         assert self.mesh.ndim == 1, "Only support 1-d device mesh for now"

--- a/spmd/tensor/ops/math_ops.py
+++ b/spmd/tensor/ops/math_ops.py
@@ -1,7 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from torch.distributed.distributed_c10d import (
-    ReduceOp
-)
+from torch.distributed.distributed_c10d import ReduceOp
 from spmd.tensor.api import Tensor
 from spmd.tensor.placement_types import Shard, Replicate, _Partial
 from spmd.tensor.ops.utils import register_impl
@@ -15,7 +13,9 @@ def dist_sum(self: Tensor) -> Tensor:
 
     local_sum = self_local.sum()
 
-    if isinstance(self_placement, Shard) or isinstance(self_placement, _Partial):
+    if isinstance(self_placement, Shard) or isinstance(
+        self_placement, _Partial
+    ):
         placements = [_Partial(ReduceOp.SUM)]
         # partial reduce
         partial_sum = Tensor.from_local(local_sum, device_mesh, placements)
@@ -23,6 +23,8 @@ def dist_sum(self: Tensor) -> Tensor:
         replicate_placements = [Replicate()]
         return partial_sum.redistribute(device_mesh, replicate_placements)
     elif isinstance(self_placement, Replicate):
-        return Tensor.from_local(local_sum, device_mesh=device_mesh, placements=self.placements)
+        return Tensor.from_local(
+            local_sum, device_mesh=device_mesh, placements=self.placements
+        )
     else:
         raise RuntimeError("Not supported!")

--- a/spmd/tensor/ops/matrix_ops.py
+++ b/spmd/tensor/ops/matrix_ops.py
@@ -1,58 +1,76 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # implement matrix related ops for distributed tensor
 import torch.utils._pytree as pytree
-from torch.distributed.distributed_c10d import (
-    ReduceOp
-)
+from torch.distributed.distributed_c10d import ReduceOp
 from spmd.tensor.api import Tensor
-from spmd.tensor.placement_types import (
-    Shard,
-    Replicate,
-    _Partial
-)
+from spmd.tensor.placement_types import Shard, Replicate, _Partial
 from spmd.tensor.ops.utils import (
     unwrap_local_tensor,
     unwrap_single_placement,
     is_shard_on_dim,
-    register_impl
+    register_impl,
 )
 
 
 @register_impl("aten.addmm.default")
-def dist_addmm(input: Tensor, mat1: Tensor, mat2: Tensor, beta=1, alpha=1) -> Tensor:
+def dist_addmm(
+    input: Tensor, mat1: Tensor, mat2: Tensor, beta=1, alpha=1
+) -> Tensor:
     # dist addmm:
     # input:shard(0)    mat1: shard(0),  mat2: replicate
     # input:shard(1)    mat1: replicate, mat2: shard(1)
     # input:replicate   mat1: shard(0),  mat2: replicate
     # input:replicate   mat1: replicate, mat2: shard(1)
     # input:replicate   mat1: shard(0),  mat2: shard(1)
-    local_input, local_mat1, local_mat2 = pytree.tree_map(unwrap_local_tensor, (input, mat1, mat2))
-    input_placement, mat1_placement, mat2_placement = pytree.tree_map(unwrap_single_placement, (input, mat1, mat2))
+    local_input, local_mat1, local_mat2 = pytree.tree_map(
+        unwrap_local_tensor, (input, mat1, mat2)
+    )
+    input_placement, mat1_placement, mat2_placement = pytree.tree_map(
+        unwrap_single_placement, (input, mat1, mat2)
+    )
     device_mesh = mat1.device_mesh
     world_size = device_mesh.size()
     current_rank = device_mesh.get_rank()
 
-    assert isinstance(input_placement, Replicate), "only support replication now"
+    assert isinstance(
+        input_placement, Replicate
+    ), "only support replication now"
 
     # only implemented combo with no comm for now
     # TODO: implement all combinations
-    if isinstance(mat1_placement, Shard) and isinstance(mat2_placement, Replicate):
+    if isinstance(mat1_placement, Shard) and isinstance(
+        mat2_placement, Replicate
+    ):
         mat1_shard_dim = mat1_placement.dim
         chunk_size = mat1.size(0) // world_size
         assert mat1_shard_dim == 0, "shard dim should be 0!"
-        local_res = local_input.addmm(local_mat1, local_mat2, beta=beta, alpha=alpha)
+        local_res = local_input.addmm(
+            local_mat1, local_mat2, beta=beta, alpha=alpha
+        )
         return Tensor.from_local(local_res, device_mesh, mat1.placements)
-    elif isinstance(mat1_placement, Replicate) and isinstance(mat2_placement, Shard):
+    elif isinstance(mat1_placement, Replicate) and isinstance(
+        mat2_placement, Shard
+    ):
         mat2_shard_dim = mat2_placement.dim
         assert mat2_shard_dim == 1, "shard dim should be 1!"
         chunk_size = mat1.size(1) // world_size
-        local_res = local_input.addmm(local_mat1, local_mat2, beta=beta, alpha=alpha)
+        local_res = local_input.addmm(
+            local_mat1, local_mat2, beta=beta, alpha=alpha
+        )
         return Tensor.from_local(local_res, device_mesh, mat2.placements)
-    elif isinstance(mat1_placement, Replicate) and isinstance(mat2_placement, Replicate):
-        local_res = local_input.addmm(local_mat1, local_mat2, beta=beta, alpha=alpha)
-        return Tensor.from_local(local_res, device_mesh, mat1.placements, run_check=False)
+    elif isinstance(mat1_placement, Replicate) and isinstance(
+        mat2_placement, Replicate
+    ):
+        local_res = local_input.addmm(
+            local_mat1, local_mat2, beta=beta, alpha=alpha
+        )
+        return Tensor.from_local(
+            local_res, device_mesh, mat1.placements, run_check=False
+        )
     else:
-        raise RuntimeError(f"addmm operator supported for inputs: {mat1}, {mat2}")
+        raise RuntimeError(
+            f"addmm operator supported for inputs: {mat1}, {mat2}"
+        )
 
 
 @register_impl("aten.mm.default")
@@ -63,7 +81,9 @@ def dist_mm(mat1: Tensor, mat2: Tensor) -> Tensor:
     # mat1: shard(1),  mat2: shard(0)
     # mat1: shard(0),  mat2: shard(1)
     local_mat1, local_mat2 = pytree.tree_map(unwrap_local_tensor, (mat1, mat2))
-    mat1_placement, mat2_placement = pytree.tree_map(unwrap_single_placement, (mat1, mat2))
+    mat1_placement, mat2_placement = pytree.tree_map(
+        unwrap_single_placement, (mat1, mat2)
+    )
     device_mesh = mat1.device_mesh
 
     # print(f"?????!!! sharded mm mat1 size: {mat1.size()}, mat2 size: {mat2.size()}")
@@ -71,13 +91,19 @@ def dist_mm(mat1: Tensor, mat2: Tensor) -> Tensor:
 
     # only implemented the first 3
     # TODO: implement all combinations
-    if is_shard_on_dim(mat1_placement, 0) and isinstance(mat2_placement, Replicate):
+    if is_shard_on_dim(mat1_placement, 0) and isinstance(
+        mat2_placement, Replicate
+    ):
         local_res = local_mat1.mm(local_mat2)
         return Tensor.from_local(local_res, device_mesh, mat1.placements)
-    elif isinstance(mat1_placement, Replicate) and is_shard_on_dim(mat2_placement, 1):
+    elif isinstance(mat1_placement, Replicate) and is_shard_on_dim(
+        mat2_placement, 1
+    ):
         local_res = local_mat1.mm(local_mat2)
         return Tensor.from_local(local_res, device_mesh, mat2.placements)
-    elif is_shard_on_dim(mat1_placement, 1) and is_shard_on_dim(mat2_placement, 0):
+    elif is_shard_on_dim(mat1_placement, 1) and is_shard_on_dim(
+        mat2_placement, 0
+    ):
         local_res = local_mat1.mm(local_mat2)
         placements = [_Partial(ReduceOp.SUM)]
         partial_sum = Tensor.from_local(local_res, device_mesh, placements)
@@ -98,4 +124,6 @@ def dist_t(self: Tensor) -> Tensor:
     device_mesh = self.device_mesh
 
     new_shard_dim = 1 if is_shard_on_dim(mat_placement, 0) else 0
-    return Tensor.from_local(transposed_local_mat, device_mesh, [Shard(new_shard_dim)])
+    return Tensor.from_local(
+        transposed_local_mat, device_mesh, [Shard(new_shard_dim)]
+    )

--- a/spmd/tensor/ops/tensor_ops.py
+++ b/spmd/tensor/ops/tensor_ops.py
@@ -13,11 +13,19 @@ def dist_detach(self):
 
 
 @register_impl("aten.ones_like.default")
-def dist_ones_like(self, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None):
+def dist_ones_like(
+    self,
+    dtype=None,
+    layout=None,
+    device=None,
+    pin_memory=None,
+    memory_format=None,
+):
     device_mesh = self.device_mesh
 
     new_local_tensor = torch.ones_like(self.local_tensor())
     return Tensor.from_local(new_local_tensor, device_mesh, self.placements)
+
 
 # @register_impl("aten.expand.default")
 # def dist_expand(types, args=(), kwargs=None):

--- a/spmd/tensor/ops/utils.py
+++ b/spmd/tensor/ops/utils.py
@@ -19,6 +19,7 @@ def unwrap_local_tensor(e):
 def is_shard_on_dim(placement, dim):
     return isinstance(placement, Shard) and placement.dim == dim
 
+
 # convenient wrapper to register functions
 
 

--- a/spmd/tensor/redistribute.py
+++ b/spmd/tensor/redistribute.py
@@ -1,68 +1,76 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 import spmd.tensor.api as spmd_tensor
-from spmd.tensor.placement_types import (
-    Shard,
-    Replicate,
-    _Partial
-)
+from spmd.tensor.placement_types import Shard, Replicate, _Partial
 
 
 def redistribute_spmd_tensor(input, device_mesh, placements):
     current_placements = input.placements
-    if isinstance(current_placements[0], Shard) and isinstance(placements[0], Replicate):
+    if isinstance(current_placements[0], Shard) and isinstance(
+        placements[0], Replicate
+    ):
         assert len(placements) == 1, "Only support 1-d placement for now"
-        assert input.device_mesh.mesh.equal(device_mesh.mesh), "cross mesh comm not support yet"
+        assert input.device_mesh.mesh.equal(
+            device_mesh.mesh
+        ), "cross mesh comm not support yet"
         # record in ctx
         # for shard, all_gather all shards and return the global tensor
         global_tensor = torch.empty(
-            input.size(),
-            device=input._local_tensor.device,
-            dtype=input.dtype
+            input.size(), device=input._local_tensor.device, dtype=input.dtype
         )
         # NOTE: all_gather_base only works well when tensor
         # sharded on a sequential list of devices
         device_mesh.all_gather_base(global_tensor, input._local_tensor)
-        replica_tensor = spmd_tensor.Tensor.from_local(global_tensor, device_mesh, placements)
+        replica_tensor = spmd_tensor.Tensor.from_local(
+            global_tensor, device_mesh, placements
+        )
         replica_tensor._placements[0] = Replicate()
         return replica_tensor
-    elif isinstance(current_placements[0], _Partial) and isinstance(placements[0], Replicate):
-        reduced_tensor = device_mesh.all_reduce(input._local_tensor, current_placements[0].reduce_op)
-        replica_tensor = spmd_tensor.Tensor.from_local(reduced_tensor, device_mesh, current_placements)
+    elif isinstance(current_placements[0], _Partial) and isinstance(
+        placements[0], Replicate
+    ):
+        reduced_tensor = device_mesh.all_reduce(
+            input._local_tensor, current_placements[0].reduce_op
+        )
+        replica_tensor = spmd_tensor.Tensor.from_local(
+            reduced_tensor, device_mesh, current_placements
+        )
         # change placement to replicate
         replica_tensor._placements[0] = Replicate()
         return replica_tensor
-    elif isinstance(current_placements[0], Replicate) and isinstance(placements[0], Shard):
+    elif isinstance(current_placements[0], Replicate) and isinstance(
+        placements[0], Shard
+    ):
         # slice the tensor to local shard then return shard tensor
         local_tensor = input.local_tensor()
         shard_dim = placements[0].dim
         num_chunks = device_mesh.size()
-        assert input.size(shard_dim) % num_chunks == 0, "Only support chunk sharding evenly now"
+        assert (
+            input.size(shard_dim) % num_chunks == 0
+        ), "Only support chunk sharding evenly now"
         chunk_size = input.size(shard_dim) // num_chunks
         my_rank = device_mesh.get_rank()
-        local_shard = local_tensor[my_rank * chunk_size, (my_rank + 1) * chunk_size]
-        return spmd_tensor.Tensor.from_local(local_shard, device_mesh, placements)
+        local_shard = local_tensor[
+            my_rank * chunk_size, (my_rank + 1) * chunk_size
+        ]
+        return spmd_tensor.Tensor.from_local(
+            local_shard, device_mesh, placements
+        )
     elif current_placements == placements:
         return input
     else:
-        raise RuntimeError(f"Converting from {current_placements} to {placements} not supported!")
+        raise RuntimeError(
+            f"Converting from {current_placements} to {placements} not supported!"
+        )
 
 
 class Redistribute(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input, device_mesh, placements):
         ctx.previous_placement = input.placements
-        return redistribute_spmd_tensor(
-            input,
-            device_mesh,
-            placements
-        )
+        return redistribute_spmd_tensor(input, device_mesh, placements)
 
     @staticmethod
     def backward(ctx, grad_output):
         previous_placement = ctx.previous_placement
-        return redistribute_spmd_tensor(
-            input,
-            device_mesh,
-            previous_placement
-        )
+        return redistribute_spmd_tensor(input, device_mesh, previous_placement)

--- a/spmd/tensor/utils.py
+++ b/spmd/tensor/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # from .api import Tensor
 
+
 def all_equal(xs):
     xs = list(xs)
     if not xs:

--- a/test/spmd/tensor/test_ops.py
+++ b/test/spmd/tensor/test_ops.py
@@ -1,15 +1,8 @@
 import torch
-from torch.testing._internal.common_utils import (
-    run_tests
-)
+from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms
-from spmd import (
-    distribute_tensor,
-    DeviceMesh,
-    Tensor,
-    Shard,
-    Replicate
-)
+from spmd import distribute_tensor, DeviceMesh, Tensor, Shard, Replicate
+
 
 class DistTensorOpsTest(DistTensorTestBase):
     @with_comms
@@ -26,8 +19,13 @@ class DistTensorOpsTest(DistTensorTestBase):
         input = distribute_tensor(input_tensor, device_mesh, replica_spec)
 
         dist_res = torch.addmm(input, mat1, mat2)
-        local_res = torch.addmm(input_tensor, tensor_to_shard, tensor_to_replicate)
-        self.assertEqual(dist_res.redistribute(device_mesh, replica_spec).local_tensor(), local_res)
+        local_res = torch.addmm(
+            input_tensor, tensor_to_shard, tensor_to_replicate
+        )
+        self.assertEqual(
+            dist_res.redistribute(device_mesh, replica_spec).local_tensor(),
+            local_res,
+        )
 
     @with_comms
     def test_mm(self):
@@ -42,7 +40,10 @@ class DistTensorOpsTest(DistTensorTestBase):
 
         dist_res = torch.mm(mat1, mat2)
         local_res = torch.mm(tensor_to_shard, tensor_to_replicate)
-        self.assertEqual(dist_res.redistribute(device_mesh, replica_spec).local_tensor(), local_res)
+        self.assertEqual(
+            dist_res.redistribute(device_mesh, replica_spec).local_tensor(),
+            local_res,
+        )
 
         # backward
         grad_res = torch.ones(12, 16)
@@ -96,9 +97,10 @@ class DistTensorOpsTest(DistTensorTestBase):
 
         input_tensor = torch.randn(4, 8, requires_grad=True)
         dist_tensor = Tensor.from_local(input_tensor, device_mesh, shard_spec)
-        ones_like_dt = torch.ones_like(dist_tensor) 
+        ones_like_dt = torch.ones_like(dist_tensor)
         ones_expected = torch.ones(4, 8)
         self.assertEqual(ones_expected, ones_like_dt.local_tensor())
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()

--- a/test/spmd/test_utils.py
+++ b/test/spmd/test_utils.py
@@ -1,4 +1,3 @@
-
 import sys
 
 import torch
@@ -11,6 +10,7 @@ from torch.testing._internal.common_distributed import (
 )
 
 TEST_GPU_NUM = 4
+
 
 class DistTensorTestBase(MultiProcessTestCase):
     @property
@@ -44,13 +44,17 @@ class DistTensorTestBase(MultiProcessTestCase):
         super().setUp()
         self._spawn_processes()
 
+
 # wrapper to initialize comms (processgroup)
 def with_comms(func=None, backend=None):
     assert func is not None
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # if backend not specified, and cuda available, then use nccl, else gloo
-        pg_backend = "nccl" if backend is None and torch.cuda.is_available() else "gloo"
+        pg_backend = (
+            "nccl" if backend is None and torch.cuda.is_available() else "gloo"
+        )
         if pg_backend == "nccl" and torch.cuda.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
@@ -58,4 +62,5 @@ def with_comms(func=None, backend=None):
         self.init_pg(backend=pg_backend)
         func(self)
         self.destroy_pg()
+
     return wrapper


### PR DESCRIPTION
This PR changes the CI config to enable the black linter for `spmd` and `test/spmd` folders only. It also fixes the lint errors.

