### PR TITLE
[spmd] Support N-D DeviceMesh

### DIFF
--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -24,7 +24,7 @@ def distribute_tensor(
     tensor = tensor.to(device_mesh.device_type)
     # set default placements to replicated if not specified
     if placements is None:
-        placements = [Replicate() for _ in device_mesh.ndim]
+        placements = [Replicate() for _ in range(device_mesh.ndim)]
 
     # distribute the tensor according to PlacementSpec
     assert len(placements) == 1, "Only support 1-d placement now"

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -1,10 +1,14 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+from typing import List, Any
 import torch
 from torch.distributed.distributed_c10d import (
     get_rank,
+    get_world_size,
     ReduceOp,
     _get_default_group,
     _reduce_scatter_base,
+    new_group,
+    ProcessGroup,
 )
 
 # autograd enabled collective
@@ -16,48 +20,70 @@ from torch.distributed.nn.functional import (
     scatter,
 )
 
-# pyre-fixme[5]: Global expression must be annotated.
-_global_device_mesh = None
+_global_device_mesh: "DeviceMesh" = None
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def get_global_device_mesh():
+def get_global_device_mesh() -> "DeviceMesh":
     global _global_device_mesh
     return _global_device_mesh
 
 
-# pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def set_global_device_mesh(mesh):
+def set_global_device_mesh(mesh: "DeviceMesh") -> None:
     global _global_device_mesh
     _global_device_mesh = mesh
 
 
 class DeviceMesh(object):
     """
-    Device Mesh object, can be used as a context manager.
-    By default describes the device ids, layout and serves
-    as a proxy for communication among the device lists.
+    DeviceMesh represents a mesh of devices, where layout of
+    devices could be represented as a n-d dimension array, and
+    each value of the n-d dimensional array is the global id
+    of the default process group ranks.
+
+    DeviceMesh could be used to describe the layout of devices
+    across the cluster, and serves as a proxy for communication
+    among the device lists within the cluster.
 
     We use the default ProcessGroup in this DeviceMesh class
     to implement proper communications. Note that we also
     add collective wrappers in this class. This is used to
     decouple detailed communication backend with the underlying
     DistributedTensor implementation.
+
+    DeviceMesh can be used as a context manager.
+
+    Example (2 host with 4 GPUs each):
+        ```
+        # The following program runs on each process/rank in SPMD manner.
+        # initialized default world
+        torch.distributed.init_process_group(backend="nccl", world_size=8)
+        # initialize device mesh as (2, 4) to represent the topology
+        # of cross-host(dim 0), and within-host (dim 1)
+        mesh = DeviceMesh(device_type="cuda",
+                          mesh=[
+                            [0, 1, 2, 3],
+                            [4, 5, 6, 7]
+                          ])
+        ```
+        A reduction over the first dimension of mesh will reduce across
+        columns (0, 4), .. and (3, 7), a reduction over the second dimension
+        of mesh reduces across rows (0, 1, 2, 3) and (4, 5, 6, 7)
+
     """
 
     device_type: str
     mesh: torch.Tensor
-    # _world_pg: ProcessGroup
 
-    # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
-    def __init__(self, device_type, mesh):
+    def __init__(
+        self, device_type: str, mesh, dim_groups: List[List[ProcessGroup]] = None
+    ) -> None:
         self.device_type = device_type
-        self.mesh = torch.Tensor(mesh)
-
+        self.mesh = torch.tensor(mesh, dtype=torch.int)
         default_pg = _get_default_group()
         backend_name = default_pg._get_backend_name()
+        # TODO: if user want to pass pg_options, offer a way to
+        # check default pg backend, should support device_type
         if device_type == "cpu":
             assert (
                 backend_name == "gloo"
@@ -69,61 +95,114 @@ class DeviceMesh(object):
                 f"DeviceMesh only support cpu or cuda device type, but got {device_type}"
             )
 
-        # TODO: support multi-dimensional device mesh
-        assert self.mesh.ndim == 1, "Only support 1-d device mesh for now"
+        world_size = get_world_size()
+        if self.mesh.numel() > world_size:
+            raise RuntimeError(
+                f"Mesh should not be bigger than default world size, but found {self.mesh.numel()} ranks!"
+            )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def __enter__(self):
+        unique_mesh_values = self.mesh.unique(sorted=True)
+        if unique_mesh_values.numel() != self.mesh.numel():
+            raise RuntimeError(
+                f"DeviceMesh cannot have duplicate values, but found {self.mesh.tolist()}"
+            )
+
+        if dim_groups is not None:
+            # if user hand creating dimension based groups
+            # we just take it and use it for communication
+            # we assume user passing dim_gruops are legit
+            # TODO: add more checks to check the correctness
+            # of user passed in dim groups
+            self._dim_to_groups = dim_groups
+            return
+
+        self._dim_to_groups: List[List[ProcessGroup]] = [
+            [] for _ in range(self.mesh.ndim)
+        ]
+        # create sub pgs base on the mesh argument
+        for dim in range(self.mesh.ndim):
+            subgroups_by_dim = self._dim_to_groups[dim]
+            # generate flattened mesh for dim, to create subgroups
+            unbinded_mesh = self.mesh.unbind(dim)
+            flattened_mesh = [submesh.flatten() for submesh in unbinded_mesh]
+            stacked_mesh = torch.stack(flattened_mesh)
+
+            if self.mesh.ndim == 1:
+                if unique_mesh_values[-1] == world_size - 1:
+                    # we just append the default pg to the first
+                    # dim goups, as new_group cannot have the
+                    # exact same ranks as world
+                    subgroups_by_dim.append(default_pg)
+                else:
+                    # smaller than world, create new group
+                    subgroups_by_dim.append(
+                        new_group(ranks=self.mesh, backend=backend_name)
+                    )
+            else:
+                # multi-dim mesh, create subgroups by
+                # looping over the transposed stacked_mesh
+                # and append the groups
+                for dim_mesh in stacked_mesh.T:
+                    subgroup_ranks = dim_mesh.tolist()
+                    subgroups_by_dim.append(
+                        new_group(
+                            ranks=subgroup_ranks,
+                            backend=backend_name,
+                        )
+                    )
+
+    def __enter__(self) -> "DeviceMesh":
         # set global device_mesh to this instance
         set_global_device_mesh(self)
         return self
 
-    # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
         # unset global device mesh
         set_global_device_mesh(None)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def __repr__(self):
-        return f"DeviceMesh:({self.mesh})"
+    def __repr__(self) -> str:
+        return f"DeviceMesh:({self.mesh.tolist()})"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, DeviceMesh):
+            return False
+        if id(self) == id(other):
+            return True
+        return self.mesh.equal(other.mesh)
+
+    def get_dim_groups(self) -> List[List[ProcessGroup]]:
+        return self._dim_to_groups
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def size(self, dim=0):
+    def size(self, dim: int = 0):
         return self.mesh.size(dim)
 
     @property
-    # pyre-fixme[3]: Return type must be annotated.
-    def ndim(self):
+    def ndim(self) -> int:
         return self.mesh.ndim
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def backend(self):
+    def backend(self) -> str:
         return _get_default_group()._get_backend_name()
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def get_rank(self):
+    def get_rank(self) -> int:
         return get_rank()
 
-    # pyre-fixme[2]: Parameter must be annotated.
-    def scatter(self, tensors, src=0) -> torch.Tensor:
-        current_rank = get_rank()
+    def scatter(self, tensors: List[torch.Tensor], src: int = 0) -> torch.Tensor:
         return scatter(tensors, src=src)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def broadcast(self, tensor, src=0):
-        return broadcast(tensor, src=src)
+    def broadcast(self, tensor: torch.Tensor, mesh_dim: int = 0):
+        sub_pgs = self._dim_to_groups[mesh_dim]
+        for pg in sub_pgs:
+            broadcast(tensor, src=0, group=pg)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def all_gather(self, tensor):
+    def all_gather(self, tensor: torch.Tensor):
         return all_gather(tensor)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def all_gather_base(self, output_tensor, tensor):
+    def all_gather_base(self, output_tensor: torch.Tensor, tensor: torch.Tensor):
         # only nccl have all_gather base
         if self.backend() == "nccl":
             return _all_gather_base(output_tensor, tensor)
@@ -137,13 +216,13 @@ class DeviceMesh(object):
             return output_tensor
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def all_reduce(self, tensor, op=ReduceOp.SUM):
+    def all_reduce(self, tensor: torch.Tensor, op=ReduceOp.SUM):
         return all_reduce(tensor, op=op)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def reduce_scatter_base(self, output, input, op=ReduceOp.SUM):
+    def reduce_scatter_base(
+        self, output: torch.Tensor, input: torch.Tensor, op=ReduceOp.SUM
+    ):
         # NOTE: two caveats:
         # 1. only NCCL support reduce_scatter
         # 2. we are using a non-autograd enabled reduce_scatter

--- a/spmd/tensor/ops/dropout.py
+++ b/spmd/tensor/ops/dropout.py
@@ -10,7 +10,7 @@ def _dist_dropout(self: Tensor, p: float, train: bool) -> Tuple[Tensor, Tensor]:
     self_placement = self.placements[0]
     # TODO: To figure out why partial tensor does not dispatch here when in CPU.
     # and with kwargs.
-    if self_placement.is_partial() or self_placement.replicate():
+    if self_placement.is_partial() or self_placement.is_replicate():
         raise RuntimeError("Not supported!")
     else:
         local_tensor, mask = torch.ops.aten.native_dropout(

--- a/spmd/tensor/ops/math_ops.py
+++ b/spmd/tensor/ops/math_ops.py
@@ -20,7 +20,7 @@ def dist_sum(self: Tensor) -> Tensor:
         # all_reduce across device
         replicate_placements = [Replicate()]
         return partial_sum.redistribute(device_mesh, replicate_placements)
-    elif self_placement.is_replicated():
+    elif self_placement.is_replicate():
         return Tensor.from_local(
             local_sum, device_mesh=device_mesh, placements=self.placements
         )

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import torch
+
+from torch.distributed.distributed_c10d import (
+    ProcessGroup,
+    GroupMember,
+    new_group,
+)
+from torch.testing._internal.common_utils import run_tests
+from ..test_utils import DistTensorTestBase, with_comms
+from spmd.tensor import DeviceMesh, Tensor, Shard, Replicate
+
+
+class DeviceMeshTest(DistTensorTestBase):
+    @property
+    def world_size(self):
+        return 8
+
+    @with_comms
+    def test_device_mesh_basics(self):
+        # construct a cuda device mesh
+        mesh = DeviceMesh(self.device_type, [0, 1, 2, 3])
+
+        # construct from a cpu local tensor with cuda device mesh
+        # should automatically convert the dist tensor to cuda
+        shard_spec = [Shard(0)]
+        local_tensor = torch.randn(3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+
+    @with_comms
+    def test_device_mesh_context_manager(self):
+        with DeviceMesh(self.device_type, list(range(self.world_size))) as mesh:
+            shard_spec = [Shard(0)]
+            local_tensor = torch.randn(3, 3)
+            sharded_tensor = Tensor.from_local(
+                local_tensor, device_mesh=mesh, placements=shard_spec
+            )
+
+        with DeviceMesh(self.device_type, list(range(self.world_size))):
+            shard_spec = [Shard(0)]
+            local_tensor = torch.randn(3, 3)
+            sharded_tensor = Tensor.from_local(local_tensor, placements=shard_spec)
+            replica_spec = [Replicate()]
+            replica_tensor = sharded_tensor.redistribute(placements=replica_spec)
+            self.assertEqual(
+                replica_tensor.size(), torch.Size([3 * self.world_size, 3])
+            )
+
+    @with_comms
+    def test_device_mesh_2d(self):
+        # construct a cuda device mesh
+        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
+
+        # check first dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        first_dim_groups = dim_to_subgroups[0]
+        self.assertEqual(len(first_dim_groups), 2)
+        # first dim subgroups should be [0, 2], [1, 3]
+        first_dim_expected_ranks = [[0, 2], [1, 3]]
+        for i, first_dim_group in enumerate(first_dim_groups):
+            group_ranks = first_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(first_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # check second dim groups
+        second_dim_groups = dim_to_subgroups[1]
+        self.assertEqual(len(second_dim_groups), 2)
+        # second dim subgroups should be [0, 1], [2, 3]
+        second_dim_expected_ranks = [[0, 1], [2, 3]]
+        for i, second_dim_group in enumerate(second_dim_groups):
+            group_ranks = second_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(second_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # construct a dist tensor on 2d device mesh and test if works
+        shard_spec = [Shard(0), Shard(1)]
+        local_tensor = torch.randn(3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
+        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+
+    @with_comms
+    def test_device_mesh_2d_from_dim_groups(self):
+        # construct a two dimension subgroups
+        dim_groups = []
+        dim_expected_ranks = [[[0, 2], [1, 3]], [[0, 1], [2, 3]]]
+        for dim_group_ranks in dim_expected_ranks:
+            per_dim_groups = []
+            for subgroup_ranks in dim_group_ranks:
+                per_dim_groups.append(new_group(ranks=subgroup_ranks))
+            dim_groups.append(per_dim_groups)
+
+        # construct a device mesh from the subgroups
+        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups)
+
+        # check first dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        first_dim_groups = dim_to_subgroups[0]
+        self.assertEqual(len(first_dim_groups), 2)
+        # first dim subgroups should be [0, 2], [1, 3]
+        first_dim_expected_ranks = [[0, 2], [1, 3]]
+        for i, first_dim_group in enumerate(first_dim_groups):
+            group_ranks = first_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(first_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # check second dim groups
+        second_dim_groups = dim_to_subgroups[1]
+        self.assertEqual(len(second_dim_groups), 2)
+        # second dim subgroups should be [0, 1], [2, 3]
+        second_dim_expected_ranks = [[0, 1], [2, 3]]
+        for i, second_dim_group in enumerate(second_dim_groups):
+            group_ranks = second_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(second_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # construct a dist tensor on 2d device mesh and test if works
+        shard_spec = [Shard(0), Shard(1)]
+        local_tensor = torch.randn(3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
+        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+
+    @with_comms
+    def test_device_mesh_nd(self):
+        # construct a cuda device mesh
+        mesh = torch.arange(8).reshape(2, 2, 2)
+        mesh = DeviceMesh(self.device_type, mesh.tolist())
+
+        # check first dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        first_dim_groups = dim_to_subgroups[0]
+        self.assertEqual(len(first_dim_groups), 4)
+        self.assertEqual(len(dim_to_subgroups[2]), 4)
+
+        # check first dim groups
+        first_dim_expected_ranks = [[0, 4], [1, 5], [2, 6], [3, 7]]
+        for i, first_dim_group in enumerate(first_dim_groups):
+            group_ranks = first_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(first_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # check second dim groups
+        second_dim_groups = dim_to_subgroups[1]
+        self.assertEqual(len(second_dim_groups), 4)
+        second_dim_expected_ranks = [[0, 2], [1, 3], [4, 6], [5, 7]]
+        for i, second_dim_group in enumerate(second_dim_groups):
+            group_ranks = second_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(second_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # check third dim groups
+        third_dim_groups = dim_to_subgroups[2]
+        self.assertEqual(len(third_dim_groups), 4)
+        third_dim_expected_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        for i, third_dim_group in enumerate(third_dim_groups):
+            group_ranks = third_dim_expected_ranks[i]
+            # groups will only be visable to the ranks involved
+            if self.rank in group_ranks:
+                self.assertIsInstance(third_dim_group, ProcessGroup)
+            else:
+                self.assertEqual(third_dim_group, GroupMember.NON_GROUP_MEMBER)
+
+        # construct a dist tensor on 3d device mesh and test if works
+        shard_spec = [Shard(0), Shard(1), Shard(2)]
+        local_tensor = torch.randn(3, 3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
+        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -3,8 +3,9 @@ import torch
 
 from torch.distributed.distributed_c10d import (
     ProcessGroup,
-    GroupMember,
     new_group,
+    get_world_size,
+    _get_global_rank,
 )
 from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms
@@ -27,7 +28,9 @@ class DeviceMeshTest(DistTensorTestBase):
         local_tensor = torch.randn(3, 3)
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
     @with_comms
     def test_device_mesh_context_manager(self):
@@ -41,44 +44,41 @@ class DeviceMeshTest(DistTensorTestBase):
         with DeviceMesh(self.device_type, list(range(self.world_size))):
             shard_spec = [Shard(0)]
             local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(local_tensor, placements=shard_spec)
+            sharded_tensor = Tensor.from_local(
+                local_tensor, placements=shard_spec
+            )
             replica_spec = [Replicate()]
-            replica_tensor = sharded_tensor.redistribute(placements=replica_spec)
+            replica_tensor = sharded_tensor.redistribute(
+                placements=replica_spec
+            )
             self.assertEqual(
                 replica_tensor.size(), torch.Size([3 * self.world_size, 3])
             )
 
     @with_comms
     def test_device_mesh_2d(self):
+        mesh_tensor = torch.arange(4).reshape(2, 2)
         # construct a cuda device mesh
-        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
+        mesh = DeviceMesh(self.device_type, mesh_tensor)
 
-        # check first dim groups
+        # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
-        first_dim_groups = dim_to_subgroups[0]
-        self.assertEqual(len(first_dim_groups), 2)
-        # first dim subgroups should be [0, 2], [1, 3]
-        first_dim_expected_ranks = [[0, 2], [1, 3]]
-        for i, first_dim_group in enumerate(first_dim_groups):
-            group_ranks = first_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(first_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
 
-        # check second dim groups
-        second_dim_groups = dim_to_subgroups[1]
-        self.assertEqual(len(second_dim_groups), 2)
-        # second dim subgroups should be [0, 1], [2, 3]
-        second_dim_expected_ranks = [[0, 1], [2, 3]]
-        for i, second_dim_group in enumerate(second_dim_groups):
-            group_ranks = second_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(second_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
+        expected_ranks_by_dim = [[[0, 2], [1, 3]], [[0, 1], [2, 3]]]
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            self.assertTrue(dim < 2)
+            dim_ranks = expected_ranks_by_dim[dim]
+
+            dim_group_size = get_world_size(dim_group)
+            self.assertIsInstance(dim_group, ProcessGroup)
+            self.assertEqual(dim_group_size, 2)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            current_rank_expected_group_ranks = (
+                dim_ranks[0] if self.rank in dim_ranks[0] else dim_ranks[1]
+            )
+            self.assertEqual(global_ranks, current_rank_expected_group_ranks)
 
         # construct a dist tensor on 2d device mesh and test if works
         shard_spec = [Shard(0), Shard(1)]
@@ -86,48 +86,49 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
+
+        # if shard on the same tensor dimension
+        # we should correctly construct the global tensor size
+        shard_same_dim_spec = [Shard(0), Shard(0)]
+        local_tensor = torch.randn(3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_same_dim_spec)
+        self.assertEqual(dist_tensor.size(), torch.Size([12, 3]))
 
     @with_comms
     def test_device_mesh_2d_from_dim_groups(self):
         # construct a two dimension subgroups
         dim_groups = []
-        dim_expected_ranks = [[[0, 2], [1, 3]], [[0, 1], [2, 3]]]
-        for dim_group_ranks in dim_expected_ranks:
-            per_dim_groups = []
+        expected_ranks_by_dim = [[[0, 2], [1, 3]], [[0, 1], [2, 3]]]
+        for dim_group_ranks in expected_ranks_by_dim:
             for subgroup_ranks in dim_group_ranks:
-                per_dim_groups.append(new_group(ranks=subgroup_ranks))
-            dim_groups.append(per_dim_groups)
+                subgroup = new_group(ranks=subgroup_ranks)
+                if self.rank in subgroup_ranks:
+                    dim_groups.append(subgroup)
 
         # construct a device mesh from the subgroups
-        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups)
+        mesh = DeviceMesh(
+            self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups
+        )
 
-        # check first dim groups
+        # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
-        first_dim_groups = dim_to_subgroups[0]
-        self.assertEqual(len(first_dim_groups), 2)
-        # first dim subgroups should be [0, 2], [1, 3]
-        first_dim_expected_ranks = [[0, 2], [1, 3]]
-        for i, first_dim_group in enumerate(first_dim_groups):
-            group_ranks = first_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(first_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            self.assertTrue(dim < 2)
+            dim_ranks = expected_ranks_by_dim[dim]
 
-        # check second dim groups
-        second_dim_groups = dim_to_subgroups[1]
-        self.assertEqual(len(second_dim_groups), 2)
-        # second dim subgroups should be [0, 1], [2, 3]
-        second_dim_expected_ranks = [[0, 1], [2, 3]]
-        for i, second_dim_group in enumerate(second_dim_groups):
-            group_ranks = second_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(second_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
+            dim_group_size = get_world_size(dim_group)
+            self.assertIsInstance(dim_group, ProcessGroup)
+            self.assertEqual(dim_group_size, 2)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            current_rank_expected_group_ranks = (
+                dim_ranks[0] if self.rank in dim_ranks[0] else dim_ranks[1]
+            )
+            self.assertEqual(global_ranks, current_rank_expected_group_ranks)
 
         # construct a dist tensor on 2d device mesh and test if works
         shard_spec = [Shard(0), Shard(1)]
@@ -135,53 +136,34 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
     @with_comms
     def test_device_mesh_nd(self):
         # construct a cuda device mesh
-        mesh = torch.arange(8).reshape(2, 2, 2)
-        mesh = DeviceMesh(self.device_type, mesh.tolist())
+        mesh_tensor = torch.arange(8).reshape(2, 2, 2)
+        mesh = DeviceMesh(self.device_type, mesh_tensor)
 
-        # check first dim groups
+        # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
-        first_dim_groups = dim_to_subgroups[0]
-        self.assertEqual(len(first_dim_groups), 4)
-        self.assertEqual(len(dim_to_subgroups[2]), 4)
 
-        # check first dim groups
-        first_dim_expected_ranks = [[0, 4], [1, 5], [2, 6], [3, 7]]
-        for i, first_dim_group in enumerate(first_dim_groups):
-            group_ranks = first_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(first_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(first_dim_group, GroupMember.NON_GROUP_MEMBER)
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            self.assertTrue(dim < mesh_tensor.ndim)
+            dim_ranks = mesh_tensor.swapdims(-1, dim).reshape(-1, 2)
+            # print(dim_ranks)
+            # dim_ranks = expected_ranks_by_dim[dim]
 
-        # check second dim groups
-        second_dim_groups = dim_to_subgroups[1]
-        self.assertEqual(len(second_dim_groups), 4)
-        second_dim_expected_ranks = [[0, 2], [1, 3], [4, 6], [5, 7]]
-        for i, second_dim_group in enumerate(second_dim_groups):
-            group_ranks = second_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(second_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(second_dim_group, GroupMember.NON_GROUP_MEMBER)
-
-        # check third dim groups
-        third_dim_groups = dim_to_subgroups[2]
-        self.assertEqual(len(third_dim_groups), 4)
-        third_dim_expected_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
-        for i, third_dim_group in enumerate(third_dim_groups):
-            group_ranks = third_dim_expected_ranks[i]
-            # groups will only be visable to the ranks involved
-            if self.rank in group_ranks:
-                self.assertIsInstance(third_dim_group, ProcessGroup)
-            else:
-                self.assertEqual(third_dim_group, GroupMember.NON_GROUP_MEMBER)
+            dim_group_size = get_world_size(dim_group)
+            self.assertIsInstance(dim_group, ProcessGroup)
+            self.assertEqual(dim_group_size, 2)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            for ranks in dim_ranks:
+                if self.rank in ranks:
+                    self.assertEqual(global_ranks, ranks.tolist())
 
         # construct a dist tensor on 3d device mesh and test if works
         shard_spec = [Shard(0), Shard(1), Shard(2)]
@@ -189,7 +171,19 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
+
+        # construct a dist tensor on 3d device mesh with some shards on same dim
+        shard_spec = [Shard(0), Shard(0), Shard(2)]
+        local_tensor = torch.randn(3, 3, 3)
+        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        self.assertEqual(dist_tensor.size(), torch.Size([12, 3, 6]))
+        self.assertEqual(dist_tensor.device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -28,9 +28,7 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
-            local_tensor, device_mesh, shard_spec
-        )
+        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
         self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
 
         replica_spec = [Replicate()]
@@ -38,9 +36,7 @@ class DistTensorTest(DistTensorTestBase):
         self.assertEqual(ddp_tensor.size(), local_tensor.size())
 
         partial_spec = [_Partial(ReduceOp.SUM)]
-        partial_tensor = Tensor.from_local(
-            local_tensor, device_mesh, partial_spec
-        )
+        partial_tensor = Tensor.from_local(local_tensor, device_mesh, partial_spec)
         self.assertEqual(partial_tensor.size(), local_tensor.size())
 
     @with_comms
@@ -48,9 +44,7 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
-            local_tensor, device_mesh, shard_spec
-        )
+        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
 
         # modify shard_spec, and dist_tensor's spec should not be changed
         shard_spec[0] = Replicate()
@@ -62,53 +56,8 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
-            local_tensor, device_mesh, shard_spec
-        )
+        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
         print(sharded_tensor.device)
-
-
-class DeviceMeshTest(DistTensorTestBase):
-    @with_comms
-    def test_device_mesh_basics(self):
-        # construct a cuda device mesh
-        mesh = DeviceMesh(self.device_type, [1, 2, 3, 4])
-
-        # construct from a cpu local tensor with cuda device mesh
-        # should automatically convert the dist tensor to cuda
-        shard_spec = [Shard(0)]
-        local_tensor = torch.randn(3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
-        self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
-
-        # only support 1d mesh as of now
-        with self.assertRaisesRegex(
-            AssertionError, "Only support 1-d device mesh for now"
-        ):
-            DeviceMesh("cuda", [[1, 2], [3, 4]])
-
-    @with_comms
-    def test_device_mesh_context_manager(self):
-        with DeviceMesh(self.device_type, list(range(self.world_size))) as mesh:
-            shard_spec = [Shard(0)]
-            local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(
-                local_tensor, device_mesh=mesh, placements=shard_spec
-            )
-
-        with DeviceMesh(self.device_type, list(range(self.world_size))):
-            shard_spec = [Shard(0)]
-            local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(
-                local_tensor, placements=shard_spec
-            )
-            replica_spec = [Replicate()]
-            replica_tensor = sharded_tensor.redistribute(
-                placements=replica_spec
-            )
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -28,7 +28,9 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
+        sharded_tensor = Tensor.from_local(
+            local_tensor, device_mesh, shard_spec
+        )
         self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
 
         replica_spec = [Replicate()]
@@ -36,7 +38,9 @@ class DistTensorTest(DistTensorTestBase):
         self.assertEqual(ddp_tensor.size(), local_tensor.size())
 
         partial_spec = [_Partial(ReduceOp.SUM)]
-        partial_tensor = Tensor.from_local(local_tensor, device_mesh, partial_spec)
+        partial_tensor = Tensor.from_local(
+            local_tensor, device_mesh, partial_spec
+        )
         self.assertEqual(partial_tensor.size(), local_tensor.size())
 
     @with_comms
@@ -44,7 +48,9 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
+        sharded_tensor = Tensor.from_local(
+            local_tensor, device_mesh, shard_spec
+        )
 
         # modify shard_spec, and dist_tensor's spec should not be changed
         shard_spec[0] = Replicate()
@@ -56,7 +62,9 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(local_tensor, device_mesh, shard_spec)
+        sharded_tensor = Tensor.from_local(
+            local_tensor, device_mesh, shard_spec
+        )
         print(sharded_tensor.device)
 
 


### PR DESCRIPTION
This PR adding N-D DeviceMesh support, concretely:

* It underlying creates subgroups according to the n-d mesh array.
* It accepts a user constructed dim based process_groups, so that
  DeviceMesh could fit into existing codebase where subgroups are
  created by hand
* basic support for creating a dist tensor from local torch.Tensor
  with multi-dim device mesh

This should make the initial step towards https://github.com/pytorch/PiPPy/issues/283

The support for operator and redistribute will be done in next few PRs.