### PR TITLE
Make mypy and flake8 happy and main branch green

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,4 +28,5 @@ exclude =
     ./torch/include,
     ./torch/lib,
     ./venv,
+    ./pippy/fx,
     *.pyi

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -551,7 +551,7 @@ class Pipe(torch.nn.Module):
             # Split from the right, one each time
             split_names = qualname.rsplit('.', 1)
             leaf = split_names[-1]
-            while(len(split_names) > 1):
+            while len(split_names) > 1:
                 prefix = split_names[0]
                 if prefix in self.new_to_old_qualname_mapping:
                     old_prefix = self.new_to_old_qualname_mapping[prefix]


### PR DESCRIPTION
```
Run flake8 pippy
pippy/IR.py:554:18: E2[7](https://github.com/pytorch/PiPPy/runs/7639334947?check_suite_focus=true#step:7:8)5 missing whitespace after keyword
pippy/fx/proxy.py:356:15: E275 missing whitespace after keyword
pippy/fx/node.py:63:15: E275 missing whitespace after keyword
pippy/fx/graph.py:551:15: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:46:11: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:137:19: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:141:23: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:153:19: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:224:15: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:29[8](https://github.com/pytorch/PiPPy/runs/7639334947?check_suite_focus=true#step:7:9):27: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:2[9](https://github.com/pytorch/PiPPy/runs/7639334947?check_suite_focus=true#step:7:10)9:27: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:364:19: E275 missing whitespace after keyword
pippy/fx/experimental/optimization.py:371:[19](https://github.com/pytorch/PiPPy/runs/7639334947?check_suite_focus=true#step:7:20): E275 missing whitespace after keyword
pippy/fx/experimental/migrate_gradual_types/constraint_transformation.py:407:27: E275 missing whitespace after keyword
Error: Process completed with exit code 1.
```