### PR TITLE
[spmd] enable distributed tensor work with torch.Tensor in autograd

### DIFF
--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -60,7 +60,7 @@ def distribute_tensor(
             tensor_list = list(tensor.chunk(num_chunks, dim=shard_dim))
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
-            local_tensor = device_mesh.scatter(tensor_list)
+            local_tensor = device_mesh.scatter(tensor_list, mesh_dim=idx)
             dist_tensor = DTensor(
                 local_tensor,
                 device_mesh,

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -46,13 +46,13 @@ def distribute_tensor(
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
             local_tensor = device_mesh.scatter(tensor_list)
-            dist_tensor = Tensor.from_local(
+            dist_tensor = Tensor(
                 local_tensor, device_mesh, placements
             )
         elif isinstance(placement, Replicate) or isinstance(
             placement, _Partial
         ):
-            dist_tensor = Tensor.from_local(tensor, device_mesh, placements)
+            dist_tensor = Tensor(tensor, device_mesh, placements)
         else:
             raise RuntimeError("Not supported!")
 

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from typing import List
+from typing import Sequence, Optional
 import torch
 import torch.nn as nn
 from spmd.tensor import Tensor, Placement, Shard, Replicate, _Partial
@@ -8,14 +8,11 @@ from spmd.tensor.device_mesh import get_global_device_mesh, DeviceMesh
 torch.__future__.set_overwrite_module_params_on_conversion(True)
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def distribute_tensor(
     tensor: torch.Tensor,
-    # pyre-fixme[9]: device_mesh has type `DeviceMesh`; used as `None`.
-    device_mesh: DeviceMesh = None,
-    # pyre-fixme[9]: placements has type `List[Placement]`; used as `None`.
-    placements: List[Placement] = None,
-):
+    device_mesh: Optional[DeviceMesh] = None,
+    placements: Optional[Sequence[Placement]] = None,
+) -> Tensor:
     # get default device mesh if there's nothing specified
     device_mesh = (
         get_global_device_mesh() if device_mesh is None else device_mesh
@@ -49,9 +46,7 @@ def distribute_tensor(
             dist_tensor = Tensor(
                 local_tensor, device_mesh, placements
             )
-        elif isinstance(placement, Replicate) or isinstance(
-            placement, _Partial
-        ):
+        elif isinstance(placement, Replicate):
             dist_tensor = Tensor(tensor, device_mesh, placements)
         else:
             raise RuntimeError("Not supported!")
@@ -63,10 +58,8 @@ def distribute_tensor(
 # pyre-fixme[3]: Return type must be annotated.
 def distribute_module(
     mod: nn.Module,
-    # pyre-fixme[9]: device_mesh has type `DeviceMesh`; used as `None`.
-    device_mesh: DeviceMesh = None,
-    # pyre-fixme[9]: spec has type `List[Placement]`; used as `None`.
-    spec: List[Placement] = None,
+    device_mesh: Optional[DeviceMesh] = None,
+    spec: Optional[Sequence[Placement]] = None,
 ):
     """
     this function coverts all module parameters

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -43,9 +43,19 @@ def distribute_tensor(
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
             local_tensor = device_mesh.scatter(tensor_list)
-            dist_tensor = Tensor(local_tensor, device_mesh, placements)
+            dist_tensor = Tensor(
+                local_tensor,
+                device_mesh,
+                placements,
+                requires_grad=local_tensor.requires_grad,
+            )
         elif isinstance(placement, Replicate):
-            dist_tensor = Tensor(tensor, device_mesh, placements)
+            dist_tensor = Tensor(
+                tensor,
+                device_mesh,
+                placements,
+                requires_grad=tensor.requires_grad,
+            )
         else:
             raise RuntimeError("Not supported!")
 

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -43,9 +43,7 @@ def distribute_tensor(
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
             local_tensor = device_mesh.scatter(tensor_list)
-            dist_tensor = Tensor(
-                local_tensor, device_mesh, placements
-            )
+            dist_tensor = Tensor(local_tensor, device_mesh, placements)
         elif isinstance(placement, Replicate):
             dist_tensor = Tensor(tensor, device_mesh, placements)
         else:

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -199,7 +199,6 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-
         # check that we are not getting mixed vanilla and Distributed tensors
         arg_list, arg_spec = tree_flatten(args)
         for arg in arg_list:

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -312,7 +312,7 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             # Otherwise, it's an activation and we should flow back the gradients
             # to the original torch.Tensor, we call an autograd function to construct
             # the dist tensor instead.
-            dist_tensor = FromTorchTensor.apply(
+            dist_tensor = FromTorchTensor.apply(  # pyre-ignore[16]: autograd func
                 local_tensor, tensor_shape, device_mesh, placements
             )
 
@@ -339,7 +339,7 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         return Redistribute.apply(self, device_mesh, placements)
 
     def local_tensor(self) -> torch.Tensor:
-        return ToTorchTensor.apply(self)
+        return ToTorchTensor.apply(self)  # pyre-ignore[16]: autograd func
 
     @property
     def placements(self) -> Sequence[Placement]:

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -124,10 +124,7 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
                 # recover tensor stride by modifying the stride that larger than
                 # the current stride on the shard_dim
                 for i in range(len(tensor_stride)):
-                    if (
-                        i < shard_dim
-                        and tensor_stride[i] > tensor_stride[shard_dim]
-                    ):
+                    if tensor_stride[i] > tensor_stride[shard_dim]:
                         tensor_stride[i] = tensor_stride[i] * device_mesh.size(
                             idx
                         )

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -288,7 +288,7 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         # created should flow back the gradients to the local_tensor, so we call an autograd
         # function to construct the dist tensor instead.
         return FromTorchTensor.apply(  # pyre-ignore[16]: autograd func
-                local_tensor, device_mesh, placements
+            local_tensor, device_mesh, placements
         )
 
     def redistribute(

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -241,7 +241,9 @@ class DeviceMesh(object):
         src_for_dim = 0
         if dim_group is not GroupMember.WORLD:
             src_for_dim = _get_global_rank(dim_group, 0)
-        tensor = torch.empty_like(to_scatter[0])
+        tensor = torch.empty_like(
+            to_scatter[0], requires_grad=to_scatter[0].requires_grad
+        )
         if src_for_dim == get_rank():
             scatter(
                 tensor,

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -261,7 +261,7 @@ class DeviceMesh(object):
         if dim_group is not GroupMember.WORLD:
             src_for_dim = _get_global_rank(dim_group, 0)
 
-        return broadcast(tensor, src=src_for_dim, group=dim_group)
+        return broadcast(tensor.contiguous(), src=src_for_dim, group=dim_group)
 
     # pyre-fixme[3]: Return type must be annotated.
     def all_gather(self, tensor: torch.Tensor, mesh_dim: int = 0):

--- a/spmd/tensor/ops/dropout.py
+++ b/spmd/tensor/ops/dropout.py
@@ -19,12 +19,12 @@ def _dist_dropout(
             self.to_local(), p=p, train=train
         )
         return (
-            DTensor.from_local(
+            DTensor(
                 local_tensor,
                 device_mesh=self.device_mesh,
                 placements=self.placements,
             ),
-            DTensor.from_local(
+            DTensor(
                 mask, device_mesh=self.device_mesh, placements=self.placements
             ),
         )

--- a/spmd/tensor/ops/math_ops.py
+++ b/spmd/tensor/ops/math_ops.py
@@ -16,12 +16,12 @@ def dist_sum(self: DTensor) -> DTensor:
     if self_placement.is_shard() or self_placement.is_partial():
         placements = [_Partial(ReduceOp.SUM)]
         # partial reduce
-        partial_sum = DTensor.from_local(local_sum, device_mesh, placements)
+        partial_sum = DTensor(local_sum, device_mesh, placements)
         # all_reduce across device
         replicate_placements = [Replicate()]
         return partial_sum.redistribute(device_mesh, replicate_placements)
     elif self_placement.is_replicate():
-        return DTensor.from_local(
+        return DTensor(
             local_sum, device_mesh=device_mesh, placements=self.placements
         )
     else:

--- a/spmd/tensor/ops/matrix_ops.py
+++ b/spmd/tensor/ops/matrix_ops.py
@@ -43,19 +43,17 @@ def dist_addmm(
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return DTensor.from_local(local_res, device_mesh, mat1.placements)
+        return DTensor(local_res, device_mesh, mat1.placements)
     elif mat1_placement.is_replicate() and mat2_placement.is_shard(dim=1):
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return DTensor.from_local(local_res, device_mesh, mat2.placements)
+        return DTensor(local_res, device_mesh, mat2.placements)
     elif mat1_placement.is_replicate() and mat2_placement.is_replicate():
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return DTensor.from_local(
-            local_res, device_mesh, mat1.placements, run_check=False
-        )
+        return DTensor(local_res, device_mesh, mat1.placements, run_check=False)
     else:
         raise RuntimeError(
             f"addmm operator supported for inputs: {mat1}, {mat2}"
@@ -104,6 +102,4 @@ def dist_t(self: DTensor) -> DTensor:
     device_mesh = self.device_mesh
 
     new_shard_dim = 1 if mat_placement.is_shard(dim=0) else 0
-    return DTensor.from_local(
-        transposed_local_mat, device_mesh, [Shard(new_shard_dim)]
-    )
+    return DTensor(transposed_local_mat, device_mesh, [Shard(new_shard_dim)])

--- a/spmd/tensor/ops/tensor_ops.py
+++ b/spmd/tensor/ops/tensor_ops.py
@@ -33,7 +33,7 @@ def dist_ones_like(
     device_mesh = self.device_mesh
 
     new_local_tensor = torch.ones_like(self.to_local())
-    return DTensor.from_local(new_local_tensor, device_mesh, self.placements)
+    return DTensor(new_local_tensor, device_mesh, self.placements)
 
 
 # @register_impl("aten.expand.default")

--- a/spmd/tensor/ops/tp_sharding_ops.py
+++ b/spmd/tensor/ops/tp_sharding_ops.py
@@ -65,9 +65,7 @@ def dist_view(self: DTensor, *shape) -> DTensor:
         *shape[sharding_dim + 1 :],
     )
     new_local_tensor = local_mat.view(*new_local_tensor_size)
-    return DTensor(
-        new_local_tensor, self.device_mesh, self.placements
-    )
+    return DTensor(new_local_tensor, self.device_mesh, self.placements)
 
 
 @register_impl("aten.transpose.int")
@@ -124,9 +122,7 @@ def dist_permute(self: DTensor, dims: List[int]) -> DTensor:
     new_sharding_dim = dims.index(sharding_dim)
     new_sharding_placement = [Shard(new_sharding_dim)]
     local_tensor = torch.ops.aten.permute(local_mat, dims=dims)
-    return DTensor(
-        local_tensor, self.device_mesh, new_sharding_placement
-    )
+    return DTensor(local_tensor, self.device_mesh, new_sharding_placement)
 
 
 @register_impl("aten.cat.default")

--- a/spmd/tensor/redistribute.py
+++ b/spmd/tensor/redistribute.py
@@ -89,7 +89,7 @@ def redistribute_spmd_tensor(
 
     assert new_local_tensor is not None, "redistribute failed!"
 
-    return spmd_tensor.Tensor.from_local(
+    return spmd_tensor.Tensor(
         new_local_tensor, device_mesh, placements
     )
 

--- a/spmd/tensor/redistribute.py
+++ b/spmd/tensor/redistribute.py
@@ -89,9 +89,7 @@ def redistribute_spmd_tensor(
 
     assert new_local_tensor is not None, "redistribute failed!"
 
-    return spmd_tensor.Tensor(
-        new_local_tensor, device_mesh, placements
-    )
+    return spmd_tensor.Tensor(new_local_tensor, device_mesh, placements)
 
 
 class Redistribute(torch.autograd.Function):

--- a/test/spmd/tensor/test_ddp.py
+++ b/test/spmd/tensor/test_ddp.py
@@ -45,6 +45,18 @@ class DistTensorAPITest(DistTensorTestBase):
         self.assertEqual(local_tensor.size(), torch.Size([3, 3]))
 
     @with_comms
+    def test_distribute_tensor_requires_grad(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        shard_spec = [Shard(0)]
+        tensor_to_shard = torch.randn(12, 3, requires_grad=True)
+        sharded_tensor = distribute_tensor(
+            tensor_to_shard, device_mesh, shard_spec
+        )
+        self.assertTrue(sharded_tensor.requires_grad)
+        self.assertTrue(sharded_tensor.is_leaf)
+        self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
+
+    @with_comms
     def test_distribute_module(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         module_to_shard = MyModel(20, 20, device=self.device_type)

--- a/test/spmd/tensor/test_matrix_ops.py
+++ b/test/spmd/tensor/test_matrix_ops.py
@@ -50,7 +50,7 @@ class DistMatrixOpsTest(DistTensorTestBase):
         grad_res = torch.ones(12, 16)
         grad_dist_res = distribute_tensor(grad_res, device_mesh, shard_spec)
         dist_res.backward(grad_dist_res)
-        print(mat1.grad)
+        # print(mat1.grad)
         # dist_res.sum().backward()
 
     @with_comms

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -20,7 +20,7 @@ class RedistributeTest(DistTensorTestBase):
         expected_tensor = torch.randn(12, 3, requires_grad=True)
         chunked_list = expected_tensor.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
-        local_tensor = chunked_list[self.rank]
+        local_tensor = chunked_list[self.rank].detach().requires_grad_()
         sharded_tensor = Tensor.from_local(
             local_tensor, device_mesh, shard_spec
         )

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -22,9 +22,7 @@ class RedistributeTest(DistTensorTestBase):
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
         # make it a leaf
-        sharded_tensor = Tensor(
-            local_tensor, device_mesh, shard_spec
-        )
+        sharded_tensor = Tensor(local_tensor, device_mesh, shard_spec)
         global_sharded_tensor = sharded_tensor.redistribute(
             device_mesh, replica_spec
         )
@@ -46,9 +44,7 @@ class RedistributeTest(DistTensorTestBase):
         replica_spec = [Replicate()]
         local_tensor = torch.randn(12, 3, requires_grad=True)
         # 1) test replicate -> replicate forward
-        replica_tensor = Tensor(
-            local_tensor, device_mesh, replica_spec
-        )
+        replica_tensor = Tensor(local_tensor, device_mesh, replica_spec)
         global_replica_tensor = replica_tensor.redistribute(
             device_mesh, replica_spec
         )
@@ -75,9 +71,7 @@ class RedistributeTest(DistTensorTestBase):
         chunked_list = local_replica.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
-        replica_tensor = Tensor(
-            local_replica, device_mesh, replica_spec
-        )
+        replica_tensor = Tensor(local_replica, device_mesh, replica_spec)
         reshard_tensor = replica_tensor.redistribute(device_mesh, shard_spec)
         self.assertEqual(reshard_tensor.size(), replica_tensor.size())
         self.assertEqual(reshard_tensor.placements, shard_spec)
@@ -103,9 +97,7 @@ class RedistributeTest(DistTensorTestBase):
         partial_spec = [_Partial(ReduceOp.SUM)]
         replica_spec = [Replicate()]
         # test partial -> replicate, which trigger all_reduce
-        partial_tensor = Tensor(
-            partial_local, device_mesh, partial_spec
-        )
+        partial_tensor = Tensor(partial_local, device_mesh, partial_spec)
         global_partial_tensor = partial_tensor.redistribute(
             device_mesh, replica_spec
         )
@@ -121,9 +113,7 @@ class RedistributeTest(DistTensorTestBase):
         shard_spec = [Shard(shard_dim)]
         partial_spec = [_Partial(ReduceOp.SUM)]
         partial_local = torch.ones(12, 3)
-        partial_tensor = Tensor(
-            partial_local, device_mesh, partial_spec
-        )
+        partial_tensor = Tensor(partial_local, device_mesh, partial_spec)
         # test partial to shard 0, trigger reduce_scatter
         scatter_shard_tensor = partial_tensor.redistribute(
             device_mesh, shard_spec
@@ -142,9 +132,7 @@ class RedistributeTest(DistTensorTestBase):
         partial_spec = [_Partial(ReduceOp.SUM)]
         partial_local = torch.ones(4, 12)
         # test partial to shard 1, trigger reduce_scatter
-        partial_tensor = Tensor(
-            partial_local, device_mesh, partial_spec
-        )
+        partial_tensor = Tensor(partial_local, device_mesh, partial_spec)
         scatter_shard_tensor = partial_tensor.redistribute(
             device_mesh, shard1_spec
         )

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -21,8 +21,10 @@ class RedistributeTest(DistTensorTestBase):
         chunked_list = expected_tensor.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
-        # make it a leaf
-        sharded_tensor = Tensor(local_tensor, device_mesh, shard_spec)
+        # direct Tensor constructor should always be leaf
+        sharded_tensor = Tensor(
+            local_tensor, device_mesh, shard_spec, requires_grad=True
+        )
         global_sharded_tensor = sharded_tensor.redistribute(
             device_mesh, replica_spec
         )
@@ -44,7 +46,9 @@ class RedistributeTest(DistTensorTestBase):
         replica_spec = [Replicate()]
         local_tensor = torch.randn(12, 3, requires_grad=True)
         # 1) test replicate -> replicate forward
-        replica_tensor = Tensor(local_tensor, device_mesh, replica_spec)
+        replica_tensor = Tensor(
+            local_tensor, device_mesh, replica_spec, requires_grad=True
+        )
         global_replica_tensor = replica_tensor.redistribute(
             device_mesh, replica_spec
         )
@@ -71,7 +75,9 @@ class RedistributeTest(DistTensorTestBase):
         chunked_list = local_replica.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
-        replica_tensor = Tensor(local_replica, device_mesh, replica_spec)
+        replica_tensor = Tensor(
+            local_replica, device_mesh, replica_spec, requires_grad=True
+        )
         reshard_tensor = replica_tensor.redistribute(device_mesh, shard_spec)
         self.assertEqual(reshard_tensor.size(), replica_tensor.size())
         self.assertEqual(reshard_tensor.placements, shard_spec)

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -43,6 +43,20 @@ class DistTensorTest(DistTensorTestBase):
             )
 
     @with_comms
+    def test_tensor_stride(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        shard_spec = [Shard(0)]
+        local_tensor = torch.randn(6, 3)
+        dist_tensor = Tensor(local_tensor, device_mesh, shard_spec)
+        self.assertEqual(dist_tensor.stride(), (self.world_size * 3, 1))
+
+        # transpose local tensor and check stride
+        transposed_tensor = local_tensor.t()
+        self.assertEqual(transposed_tensor.stride(), (1, 3))
+        dist_tensor = Tensor(transposed_tensor, device_mesh, shard_spec)
+        self.assertEqual(dist_tensor.stride(), (self.world_size, 3))
+
+    @with_comms
     def test_tensor_from_local(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -43,6 +43,91 @@ class DistTensorTest(DistTensorTestBase):
         )
         self.assertEqual(partial_tensor.size(), local_tensor.size())
 
+        # test dist tensor works with torch.Tensor during backwards
+        local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        # do some operations on local tensor
+        local_tensor_temp = local_tensor_with_grad * 3
+        # create the dist tensor with non leaf local tensor, dist tensor created
+        # should also be non leaf node
+        dist_tensor = Tensor.from_local(
+            local_tensor_temp, device_mesh, shard_spec
+        )
+        self.assertFalse(dist_tensor.is_leaf)
+        # do some random operations on dist tensor
+        output = dist_tensor * 3
+        self.assertIsInstance(output, Tensor)
+        # trigger .backward() on dist tensor directly
+        local_grad = torch.ones(3, 3)
+        grad_output = Tensor.from_local(local_grad, device_mesh, shard_spec)
+        # run backward directly on dist tensor
+        output.backward(grad_output)
+        # check it gradients flow back to original torch.Tensor
+        self.assertIsNotNone(local_tensor_with_grad.grad)
+        expected_grad = torch.ones(3, 3) * 9
+        self.assertEqual(local_tensor_with_grad.grad, expected_grad)
+
+    @with_comms
+    def test_local_tensor(self):
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        shard_spec = [Shard(0)]
+        local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+
+        sharded_tensor = Tensor.from_local(
+            local_tensor_with_grad, device_mesh, shard_spec
+        )
+        self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
+        self.assertEqual(sharded_tensor.local_tensor(), local_tensor_with_grad)
+
+        # test dist tensor works with torch.Tensor during backwards
+        # dist tensor created is a leaf node, do some operation on dist tensor
+        temp_st = sharded_tensor * 3
+
+        # do some operation on local tensor of the dist tensor
+        new_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        res = temp_st.local_tensor() + new_tensor_with_grad
+        # call backward directly on torch.Tensor, and see if it works by
+        # propagating through dist tensor
+        res.sum().backward()
+        self.assertIsNotNone(sharded_tensor.grad)
+
+        expected_grad = Tensor.from_local(
+            torch.ones(3, 3) * 3, device_mesh, shard_spec
+        )
+        self.assertEqual(
+            sharded_tensor.grad.local_tensor(), expected_grad.local_tensor()
+        )
+
+    @with_comms
+    def test_from_local_then_local_tensor(self):
+        # this test ensure end to end from torch.Tensor -> dist tensor -> torch.Tensor works
+        device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        shard_spec = [Shard(0)]
+
+        # step 1. construct from construct local tensor
+        local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        # do some operations on local tensor
+        local_tensor_temp = local_tensor_with_grad + 8
+        # step 2. create the dist tensor with non leaf local tensor, dist tensor
+        # created should also be non leaf node
+        dist_tensor = Tensor.from_local(
+            local_tensor_temp, device_mesh, shard_spec
+        )
+        self.assertFalse(dist_tensor.is_leaf)
+        # do some random operations on dist tensor
+        output = dist_tensor * 6
+        self.assertIsInstance(output, Tensor)
+
+        # step 3. do some operation on local tensor of the dist tensor
+        new_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        res = output.local_tensor() + new_tensor_with_grad
+        # call backward directly on torch.Tensor, and see if it works by
+        # propagating all the way back to the original torch.Tensor
+        res.sum().backward()
+        self.assertIsNotNone(local_tensor_with_grad.grad)
+
+        expected_grad = torch.ones(3, 3) * 6
+        self.assertEqual(local_tensor_with_grad.grad, expected_grad)
+
     @with_comms
     def test_placement_spec_read_only_after_set(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
@@ -65,7 +150,7 @@ class DistTensorTest(DistTensorTestBase):
         sharded_tensor = Tensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
-        print(sharded_tensor.device)
+        self.assertEqual(str(sharded_tensor.device), self.device_type)
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -111,7 +111,9 @@ class DistTensorTest(DistTensorTestBase):
     def test_local_tensor(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
-        local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        local_tensor_with_grad = torch.randn(
+            3, 3, device=self.device_type, requires_grad=True
+        )
 
         sharded_tensor = DTensor(
             local_tensor_with_grad, device_mesh, shard_spec, requires_grad=True
@@ -124,7 +126,9 @@ class DistTensorTest(DistTensorTestBase):
         temp_st = sharded_tensor * 3
 
         # do some operation on local tensor of the dist tensor
-        new_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        new_tensor_with_grad = torch.randn(
+            3, 3, device=self.device_type, requires_grad=True
+        )
         res = temp_st.to_local() + new_tensor_with_grad
         # call backward directly on torch.Tensor, and see if it works by
         # propagating through dist tensor
@@ -143,7 +147,9 @@ class DistTensorTest(DistTensorTestBase):
         shard_spec = [Shard(0)]
 
         # step 1. construct from construct local tensor
-        local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        local_tensor_with_grad = torch.randn(
+            3, 3, device=self.device_type, requires_grad=True
+        )
         # do some operations on local tensor
         local_tensor_temp = local_tensor_with_grad + 8
         # step 2. create the dist tensor with non leaf local tensor, dist tensor
@@ -157,7 +163,9 @@ class DistTensorTest(DistTensorTestBase):
         self.assertIsInstance(output, DTensor)
 
         # step 3. do some operation on local tensor of the dist tensor
-        new_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
+        new_tensor_with_grad = torch.randn(
+            3, 3, device=self.device_type, requires_grad=True
+        )
         res = output.to_local() + new_tensor_with_grad
         # call backward directly on torch.Tensor, and see if it works by
         # propagating all the way back to the original torch.Tensor
@@ -189,7 +197,7 @@ class DistTensorTest(DistTensorTestBase):
         sharded_tensor = DTensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
-        self.assertEqual(str(sharded_tensor.device), self.device_type)
+        self.assertEqual(sharded_tensor.device.type, self.device_type)
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -58,12 +58,11 @@ class DistTensorTest(DistTensorTestBase):
         self.assertEqual(dist_tensor.stride(), (16, 1))
 
         # if initialized from a transposed mat
-        local_tensor_t = local_tensor.t()
-        self.assertEqual(local_tensor_t.stride(), (1, 4))
+        local_tensor = torch.randn(8, 4, 8)
+        local_tensor_t = local_tensor.permute(1, 2, 0)
+        self.assertEqual(local_tensor_t.stride(), (8, 1, 32))
         dist_tensor = DTensor(local_tensor_t, device_mesh, shard1_spec)
-
-        repeated_tensor_t = local_tensor_t.repeat(1, self.world_size)
-        self.assertEqual(dist_tensor.stride(), repeated_tensor_t.stride())
+        self.assertEqual(dist_tensor.stride(), (32, 1, 32))
 
     @with_comms
     def test_tensor_from_local(self):

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -72,7 +72,7 @@ class DistTensorTest(DistTensorTestBase):
         shard_spec = [Shard(0)]
         local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
 
-        sharded_tensor = Tensor.from_local(
+        sharded_tensor = Tensor(
             local_tensor_with_grad, device_mesh, shard_spec
         )
         self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
@@ -90,7 +90,7 @@ class DistTensorTest(DistTensorTestBase):
         res.sum().backward()
         self.assertIsNotNone(sharded_tensor.grad)
 
-        expected_grad = Tensor.from_local(
+        expected_grad = Tensor(
             torch.ones(3, 3) * 3, device_mesh, shard_spec
         )
         self.assertEqual(

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -72,9 +72,7 @@ class DistTensorTest(DistTensorTestBase):
         shard_spec = [Shard(0)]
         local_tensor_with_grad = torch.randn(3, 3, requires_grad=True)
 
-        sharded_tensor = Tensor(
-            local_tensor_with_grad, device_mesh, shard_spec
-        )
+        sharded_tensor = Tensor(local_tensor_with_grad, device_mesh, shard_spec)
         self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
         self.assertEqual(sharded_tensor.local_tensor(), local_tensor_with_grad)
 
@@ -90,9 +88,7 @@ class DistTensorTest(DistTensorTestBase):
         res.sum().backward()
         self.assertIsNotNone(sharded_tensor.grad)
 
-        expected_grad = Tensor(
-            torch.ones(3, 3) * 3, device_mesh, shard_spec
-        )
+        expected_grad = Tensor(torch.ones(3, 3) * 3, device_mesh, shard_spec)
         self.assertEqual(
             sharded_tensor.grad.local_tensor(), expected_grad.local_tensor()
         )

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -62,7 +62,7 @@ class DistTensorTest(DistTensorTestBase):
         local_tensor_t = local_tensor.permute(1, 2, 0)
         self.assertEqual(local_tensor_t.stride(), (8, 1, 32))
         dist_tensor = DTensor(local_tensor_t, device_mesh, shard1_spec)
-        self.assertEqual(dist_tensor.stride(), (32, 1, 32))
+        self.assertEqual(dist_tensor.stride(), (32, 1, 128))
 
     @with_comms
     def test_tensor_from_local(self):


### PR DESCRIPTION
This PR enables distributed tensor work together with torch.Tensor
in both forward and backward, by:
* make `from_local` and `to_local` to always call autograd function, this hooks up the graph of torch.Tensor and tensor subclasses in a way that's not intrusive to the autograd engine itself
* make `DTensor.__new__` accept local_tensor and allow construction like `DTensor(local_tensor, ..)` directly, this is never differentiable and we always get a leaf tensor.  
* with this change,now dist tensor could generate grads, tensor could generate grads when appropriate after the backward pass
* bunch of bug fixes coming together with this PR.

This enable us to plug in DistributedTensor as part of the module hierarchy, instead of urging all tensors converting to DistributedTensor