### PR TITLE
Add strict mode for DT and more checks and error …

### DIFF
--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -38,7 +38,11 @@ def distribute_tensor(
             num_chunks = device_mesh.size()
             assert (
                 tensor.size(shard_dim) % num_chunks == 0
-            ), "Only support chunk sharding evenly now"
+            ), (
+                f"Only support chunk sharding evenly now, but tensor got "
+                f"dimension {shard_dim} of size {tensor.size(shard_dim)}, "
+                f"which does not divide number of shards {num_chunks}."
+            )
             chunk_size = tensor.size(shard_dim) // num_chunks
             tensor_list = list(tensor.chunk(num_chunks, dim=shard_dim))
             scatter_shape = list(tensor.size())

--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -36,9 +36,7 @@ def distribute_tensor(
             ), "Sharding dim {shard_dim} greater than tensor ndim {tensor.ndim}"
             # TODO: handle multi-dim device mesh and last shard
             num_chunks = device_mesh.size()
-            assert (
-                tensor.size(shard_dim) % num_chunks == 0
-            ), (
+            assert tensor.size(shard_dim) % num_chunks == 0, (
                 f"Only support chunk sharding evenly now, but tensor got "
                 f"dimension {shard_dim} of size {tensor.size(shard_dim)}, "
                 f"which does not divide number of shards {num_chunks}."

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -76,9 +76,8 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         for arg in arg_list:
             if isinstance(arg, torch.Tensor) and not isinstance(arg, Tensor):
                 raise RuntimeError(
-                    f'{func}: got mixed distributed and non-distributed tensors.'
+                    f"{func}: got mixed distributed and non-distributed tensors."
                 )
-
 
         def unwrap_mesh(e: Tensor) -> DeviceMesh:
             # if this tensor is not Distributed, then return none. We will reinterpret it as replicated
@@ -125,12 +124,11 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         else:
             if _DEBUG_STRICT:
                 raise RuntimeError(
-                    f'Operator {func} does not have a DistributedTensor rule registered.'
+                    f"Operator {func} does not have a DistributedTensor rule registered."
                 )
             # default to local tensor ops, this is wrong
             # but we use it now to enable more tensor property access
             else:
-                print('bypassed debug strict')
                 rs = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
                 rs = wrap(rs, args_mesh[0], args[0].placements)
                 return rs

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -1,11 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import copy
 import torch
-from torch.utils._pytree import tree_map
+from torch.utils._pytree import tree_map, tree_flatten
 from typing import Dict, Callable, Optional, Sequence
 from spmd.tensor.device_mesh import get_global_device_mesh, DeviceMesh
 from spmd.tensor.placement_types import Placement, Shard, Replicate, _Partial
 from spmd.tensor.redistribute import Redistribute
+
+"""
+If set to true, __DEBUG_STRICT will fail when an op doesn't have a sharding rule registered.
+"""
+_DEBUG_STRICT = False
 
 
 class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
@@ -65,6 +70,14 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+
+        # check that we are not getting mixed vanilla and Distributed tensors
+        arg_list, arg_spec = tree_flatten(args)
+        for arg in arg_list:
+            if isinstance(arg, torch.Tensor) and not isinstance(arg, Tensor):
+                assert False, f'{func}: got mixed distributed and non-distributed tensors.'
+
+
         def unwrap_mesh(e: Tensor) -> DeviceMesh:
             # if this tensor is not Distributed, then return none. We will reinterpret it as replicated
             if not isinstance(e, Tensor):
@@ -108,11 +121,15 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             # dispatch to distributed tensor ops
             return Tensor._dist_tensor_dispatch_ops[str(func)](*args, **kwargs)
         else:
+            if _DEBUG_STRICT:
+                assert False, f'Operator {func} does not have a DistributedTensor rule registered.'
             # default to local tensor ops, this is wrong
             # but we use it now to enable more tensor property access
-            rs = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
-            rs = wrap(rs, args_mesh[0], args[0].placements)
-            return rs
+            else:
+                print('bypassed debug strict')
+                rs = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
+                rs = wrap(rs, args_mesh[0], args[0].placements)
+                return rs
 
     @classmethod
     def from_local(

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -75,7 +75,9 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
         arg_list, arg_spec = tree_flatten(args)
         for arg in arg_list:
             if isinstance(arg, torch.Tensor) and not isinstance(arg, Tensor):
-                assert False, f'{func}: got mixed distributed and non-distributed tensors.'
+                raise RuntimeError(
+                    f'{func}: got mixed distributed and non-distributed tensors.'
+                )
 
 
         def unwrap_mesh(e: Tensor) -> DeviceMesh:
@@ -122,7 +124,9 @@ class Tensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             return Tensor._dist_tensor_dispatch_ops[str(func)](*args, **kwargs)
         else:
             if _DEBUG_STRICT:
-                assert False, f'Operator {func} does not have a DistributedTensor rule registered.'
+                raise RuntimeError(
+                    f'Operator {func} does not have a DistributedTensor rule registered.'
+                )
             # default to local tensor ops, this is wrong
             # but we use it now to enable more tensor property access
             else:


### PR DESCRIPTION
…messages

- Allow DT to fail if no implementation for specific op is present.
- Fail with good error message when mixing distributed and vanilla tensors.
- Improve error message for when sharding would result in un-even sizes.