### PR TITLE
[spmd] add multi-d tests for all_reduce, broadcast and scatter

### DIFF
--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -263,17 +263,16 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
         local_tensor = torch.ones(3, 3) * self.rank
-        expected_ranks_by_dim = [
-            [[0, 4], [2, 6], [1, 5], [3, 7]],
-            [[0, 2], [1, 3], [4, 6], [5, 7]],
-            [[0, 1], [2, 3], [4, 5], [6, 7]],
-        ]
-        for dim, dim_ranks in enumerate(expected_ranks_by_dim):
-            for ranks in dim_ranks:
-                if self.rank in ranks:
-                    reduced_tensor = mesh.all_reduce(local_tensor, mesh_dim=dim)
-                    res_num = sum(ranks)
-                    break
+
+        # check all dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            dim_group_size = get_world_size(dim_group)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            reduced_tensor = mesh.all_reduce(local_tensor, mesh_dim=dim)
+            res_num = sum(global_ranks)
             self.assertEqual(reduced_tensor, torch.ones(3, 3) * res_num)
 
     @with_comms
@@ -281,17 +280,16 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
         local_tensor = torch.ones(3, 3) * self.rank
-        expected_ranks_by_dim = [
-            [[0, 4], [2, 6], [1, 5], [3, 7]],
-            [[0, 2], [1, 3], [4, 6], [5, 7]],
-            [[0, 1], [2, 3], [4, 5], [6, 7]],
-        ]
-        for dim, dim_ranks in enumerate(expected_ranks_by_dim):
-            for ranks in dim_ranks:
-                if self.rank in ranks:
-                    received_tensor = mesh.broadcast(local_tensor, mesh_dim=dim)
-                    res_num = ranks[0]
-                    break
+
+        # check all dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            dim_group_size = get_world_size(dim_group)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            received_tensor = mesh.broadcast(local_tensor, mesh_dim=dim)
+            res_num = global_ranks[0]
             self.assertEqual(received_tensor, torch.ones(3, 3) * res_num)
 
     @with_comms
@@ -299,21 +297,17 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
-        expected_ranks_by_dim = [
-            [[0, 4], [2, 6], [1, 5], [3, 7]],
-            [[0, 2], [1, 3], [4, 6], [5, 7]],
-            [[0, 1], [2, 3], [4, 5], [6, 7]],
-        ]
-        for dim, dim_ranks in enumerate(expected_ranks_by_dim):
-            for ranks in dim_ranks:
-                scattered_tensors = [
-                    torch.ones(3, 3) * global_rank for global_rank in ranks
-                ]
-                if self.rank in ranks:
-                    received_tensor = mesh.scatter(
-                        scattered_tensors, mesh_dim=dim
-                    )
-                    break
+        # check all dim groups
+        dim_to_subgroups = mesh.get_dim_groups()
+        for dim, dim_group in enumerate(dim_to_subgroups):
+            dim_group_size = get_world_size(dim_group)
+            global_ranks = [
+                _get_global_rank(dim_group, i) for i in range(dim_group_size)
+            ]
+            scattered_tensors = [
+                torch.ones(3, 3) * global_rank for global_rank in global_ranks
+            ]
+            received_tensor = mesh.scatter(scattered_tensors, mesh_dim=dim)
             self.assertEqual(received_tensor, torch.ones(3, 3) * self.rank)
 
 

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -28,7 +28,9 @@ class DeviceMeshTest(DistTensorTestBase):
         local_tensor = torch.randn(3, 3)
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
     @with_comms
     def test_device_mesh_context_manager(self):
@@ -42,9 +44,13 @@ class DeviceMeshTest(DistTensorTestBase):
         with DeviceMesh(self.device_type, list(range(self.world_size))):
             shard_spec = [Shard(0)]
             local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(local_tensor, placements=shard_spec)
+            sharded_tensor = Tensor.from_local(
+                local_tensor, placements=shard_spec
+            )
             replica_spec = [Replicate()]
-            replica_tensor = sharded_tensor.redistribute(placements=replica_spec)
+            replica_tensor = sharded_tensor.redistribute(
+                placements=replica_spec
+            )
             self.assertEqual(
                 replica_tensor.size(), torch.Size([3 * self.world_size, 3])
             )
@@ -80,7 +86,9 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
         # if shard on the same tensor dimension
         # we should correctly construct the global tensor size
@@ -101,7 +109,9 @@ class DeviceMeshTest(DistTensorTestBase):
                     dim_groups.append(subgroup)
 
         # construct a device mesh from the subgroups
-        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups)
+        mesh = DeviceMesh(
+            self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups
+        )
 
         # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
@@ -126,7 +136,9 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
     @with_comms
     def test_device_mesh_nd(self):
@@ -159,7 +171,9 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
         # construct a dist tensor on 3d device mesh with some shards on same dim
         shard_spec = [Shard(0), Shard(0), Shard(2)]
@@ -167,7 +181,9 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
+        self.assertEqual(
+            dist_tensor.local_tensor().device.type, self.device_type
+        )
 
 
 class DeviceMeshCollectiveTest(DistTensorTestBase):
@@ -193,7 +209,9 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
     @with_comms
     def test_scatter_1d(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
-        tensor_list = [torch.ones(3, 3) * rank for rank in range(self.world_size)]
+        tensor_list = [
+            torch.ones(3, 3) * rank for rank in range(self.world_size)
+        ]
         scattered_tensor = mesh.scatter(tensor_list, mesh_dim=0)
         self.assertEqual(scattered_tensor, torch.ones(3, 3) * self.rank)
 
@@ -224,7 +242,9 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         # each rank have its own tensor, all_gather_base give a big tensor
         local_tensor = torch.ones(3, 3)
         res_tensor = torch.empty(self.world_size * 3, 3)
-        gathered_tensor = mesh.all_gather_base(res_tensor, local_tensor, mesh_dim=0)
+        gathered_tensor = mesh.all_gather_base(
+            res_tensor, local_tensor, mesh_dim=0
+        )
         self.assertEqual(gathered_tensor, torch.ones(self.world_size * 3, 3))
 
     @with_comms
@@ -290,7 +310,9 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
                     torch.ones(3, 3) * global_rank for global_rank in ranks
                 ]
                 if self.rank in ranks:
-                    received_tensor = mesh.scatter(scattered_tensors, mesh_dim=dim)
+                    received_tensor = mesh.scatter(
+                        scattered_tensors, mesh_dim=dim
+                    )
                     break
             self.assertEqual(received_tensor, torch.ones(3, 3) * self.rank)
 

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -28,9 +28,7 @@ class DeviceMeshTest(DistTensorTestBase):
         local_tensor = torch.randn(3, 3)
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
 
     @with_comms
     def test_device_mesh_context_manager(self):
@@ -44,13 +42,9 @@ class DeviceMeshTest(DistTensorTestBase):
         with DeviceMesh(self.device_type, list(range(self.world_size))):
             shard_spec = [Shard(0)]
             local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(
-                local_tensor, placements=shard_spec
-            )
+            sharded_tensor = Tensor.from_local(local_tensor, placements=shard_spec)
             replica_spec = [Replicate()]
-            replica_tensor = sharded_tensor.redistribute(
-                placements=replica_spec
-            )
+            replica_tensor = sharded_tensor.redistribute(placements=replica_spec)
             self.assertEqual(
                 replica_tensor.size(), torch.Size([3 * self.world_size, 3])
             )
@@ -86,9 +80,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
 
         # if shard on the same tensor dimension
         # we should correctly construct the global tensor size
@@ -109,9 +101,7 @@ class DeviceMeshTest(DistTensorTestBase):
                     dim_groups.append(subgroup)
 
         # construct a device mesh from the subgroups
-        mesh = DeviceMesh(
-            self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups
-        )
+        mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]], dim_groups=dim_groups)
 
         # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
@@ -136,9 +126,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
 
     @with_comms
     def test_device_mesh_nd(self):
@@ -171,9 +159,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
 
         # construct a dist tensor on 3d device mesh with some shards on same dim
         shard_spec = [Shard(0), Shard(0), Shard(2)]
@@ -181,9 +167,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.local_tensor().device.type, self.device_type)
 
 
 class DeviceMeshCollectiveTest(DistTensorTestBase):
@@ -209,9 +193,7 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
     @with_comms
     def test_scatter_1d(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
-        tensor_list = [
-            torch.ones(3, 3) * rank for rank in range(self.world_size)
-        ]
+        tensor_list = [torch.ones(3, 3) * rank for rank in range(self.world_size)]
         scattered_tensor = mesh.scatter(tensor_list, mesh_dim=0)
         self.assertEqual(scattered_tensor, torch.ones(3, 3) * self.rank)
 
@@ -242,9 +224,7 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         # each rank have its own tensor, all_gather_base give a big tensor
         local_tensor = torch.ones(3, 3)
         res_tensor = torch.empty(self.world_size * 3, 3)
-        gathered_tensor = mesh.all_gather_base(
-            res_tensor, local_tensor, mesh_dim=0
-        )
+        gathered_tensor = mesh.all_gather_base(res_tensor, local_tensor, mesh_dim=0)
         self.assertEqual(gathered_tensor, torch.ones(self.world_size * 3, 3))
 
     @with_comms
@@ -263,12 +243,11 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
         local_tensor = torch.ones(3, 3) * self.rank
-        expected_ranks_by_dim = [[[0, 4], [2, 6],
-                                  [1, 5], [3, 7]],
-                                 [[0, 2], [1, 3],
-                                  [4, 6], [5, 7]],
-                                 [[0, 1], [2, 3],
-                                  [4, 5], [6, 7]]]
+        expected_ranks_by_dim = [
+            [[0, 4], [2, 6], [1, 5], [3, 7]],
+            [[0, 2], [1, 3], [4, 6], [5, 7]],
+            [[0, 1], [2, 3], [4, 5], [6, 7]],
+        ]
         for dim, dim_ranks in enumerate(expected_ranks_by_dim):
             for ranks in dim_ranks:
                 if self.rank in ranks:
@@ -282,12 +261,11 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
         local_tensor = torch.ones(3, 3) * self.rank
-        expected_ranks_by_dim = [[[0, 4], [2, 6],
-                                  [1, 5], [3, 7]],
-                                 [[0, 2], [1, 3],
-                                  [4, 6], [5, 7]],
-                                 [[0, 1], [2, 3],
-                                  [4, 5], [6, 7]]]
+        expected_ranks_by_dim = [
+            [[0, 4], [2, 6], [1, 5], [3, 7]],
+            [[0, 2], [1, 3], [4, 6], [5, 7]],
+            [[0, 1], [2, 3], [4, 5], [6, 7]],
+        ]
         for dim, dim_ranks in enumerate(expected_ranks_by_dim):
             for ranks in dim_ranks:
                 if self.rank in ranks:
@@ -301,15 +279,16 @@ class DeviceMeshCollectiveTest(DistTensorTestBase):
         mesh_tensor = torch.arange(8).reshape(2, 2, 2)
         mesh = DeviceMesh(self.device_type, mesh_tensor)
 
-        expected_ranks_by_dim = [[[0, 4], [2, 6],
-                                  [1, 5], [3, 7]],
-                                 [[0, 2], [1, 3],
-                                  [4, 6], [5, 7]],
-                                 [[0, 1], [2, 3],
-                                  [4, 5], [6, 7]]]
+        expected_ranks_by_dim = [
+            [[0, 4], [2, 6], [1, 5], [3, 7]],
+            [[0, 2], [1, 3], [4, 6], [5, 7]],
+            [[0, 1], [2, 3], [4, 5], [6, 7]],
+        ]
         for dim, dim_ranks in enumerate(expected_ranks_by_dim):
             for ranks in dim_ranks:
-                scattered_tensors = [torch.ones(3, 3) * global_rank for global_rank in ranks]
+                scattered_tensors = [
+                    torch.ones(3, 3) * global_rank for global_rank in ranks
+                ]
                 if self.rank in ranks:
                     received_tensor = mesh.scatter(scattered_tensors, mesh_dim=dim)
                     break


### PR DESCRIPTION
add simple examples in the multi-dimensional device mesh case to test collectives: all_reduce, broadcast and scatter 