### PR TITLE
[spmd] Rename Tensor to DTensor and change APIs

### DIFF
--- a/spmd/__init__.py
+++ b/spmd/__init__.py
@@ -2,7 +2,7 @@
 from typing import List
 import torch
 import torch.nn as nn
-from spmd.tensor import Tensor, Placement, Shard, Replicate, _Partial
+from spmd.tensor import DTensor, Placement, Shard, Replicate, _Partial
 from spmd.tensor.device_mesh import get_global_device_mesh, DeviceMesh
 
 torch.__future__.set_overwrite_module_params_on_conversion(True)
@@ -46,13 +46,13 @@ def distribute_tensor(
             scatter_shape = list(tensor.size())
             scatter_shape[shard_dim] = chunk_size
             local_tensor = device_mesh.scatter(tensor_list)
-            dist_tensor = Tensor.from_local(
+            dist_tensor = DTensor.from_local(
                 local_tensor, device_mesh, placements
             )
         elif isinstance(placement, Replicate) or isinstance(
             placement, _Partial
         ):
-            dist_tensor = Tensor.from_local(tensor, device_mesh, placements)
+            dist_tensor = DTensor.from_local(tensor, device_mesh, placements)
         else:
             raise RuntimeError("Not supported!")
 

--- a/spmd/tensor/__init__.py
+++ b/spmd/tensor/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 from spmd.tensor.device_mesh import DeviceMesh
 from spmd.tensor.placement_types import Placement, Shard, Replicate, _Partial
 

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -51,7 +51,7 @@ class DeviceMesh(object):
     We use the default ProcessGroup in this DeviceMesh class to implement proper
     communications. Note that we also add collective wrappers in this class. This is
     used to decouple detailed communication backend with the underlying
-    DistributedTensor implementation.
+    DTensor implementation.
 
     DeviceMesh can be used as a context manager.
     Args:
@@ -233,7 +233,7 @@ class DeviceMesh(object):
                 mesh dimension.
 
         Returns:
-            A :class:`spmd.Tensor` object
+            A :class:`torch.Tensor` object
         """
         to_scatter = [tensor.contiguous() for tensor in scatter_list]
         dim_group = self._dim_groups[mesh_dim]

--- a/spmd/tensor/ops/dropout.py
+++ b/spmd/tensor/ops/dropout.py
@@ -2,11 +2,11 @@
 import torch
 from typing import Tuple
 from spmd.tensor.ops.utils import register_impl
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 
 
 @register_impl("aten.native_dropout.default")
-def _dist_dropout(self: Tensor, p: float, train: bool) -> Tuple[Tensor, Tensor]:
+def _dist_dropout(self: DTensor, p: float, train: bool) -> Tuple[DTensor, DTensor]:
     self_placement = self.placements[0]
     # TODO: To figure out why partial tensor does not dispatch here when in CPU.
     # and with kwargs.
@@ -14,15 +14,15 @@ def _dist_dropout(self: Tensor, p: float, train: bool) -> Tuple[Tensor, Tensor]:
         raise RuntimeError("Not supported!")
     else:
         local_tensor, mask = torch.ops.aten.native_dropout(
-            self.local_tensor(), p=p, train=train
+            self.to_local(), p=p, train=train
         )
         return (
-            Tensor.from_local(
+            DTensor.from_local(
                 local_tensor,
                 device_mesh=self.device_mesh,
                 placements=self.placements,
             ),
-            Tensor.from_local(
+            DTensor.from_local(
                 mask, device_mesh=self.device_mesh, placements=self.placements
             ),
         )

--- a/spmd/tensor/ops/dropout.py
+++ b/spmd/tensor/ops/dropout.py
@@ -6,7 +6,9 @@ from spmd.tensor.api import DTensor
 
 
 @register_impl("aten.native_dropout.default")
-def _dist_dropout(self: DTensor, p: float, train: bool) -> Tuple[DTensor, DTensor]:
+def _dist_dropout(
+    self: DTensor, p: float, train: bool
+) -> Tuple[DTensor, DTensor]:
     self_placement = self.placements[0]
     # TODO: To figure out why partial tensor does not dispatch here when in CPU.
     # and with kwargs.

--- a/spmd/tensor/ops/math_ops.py
+++ b/spmd/tensor/ops/math_ops.py
@@ -1,13 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 from torch.distributed.distributed_c10d import ReduceOp
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 from spmd.tensor.placement_types import Replicate, _Partial
 from spmd.tensor.ops.utils import register_impl
 
 
 @register_impl("aten.sum.default")
-def dist_sum(self: Tensor) -> Tensor:
-    self_local = self.local_tensor()
+def dist_sum(self: DTensor) -> DTensor:
+    self_local = self.to_local()
     self_placement = self.placements[0]
     device_mesh = self.device_mesh
 
@@ -16,12 +16,12 @@ def dist_sum(self: Tensor) -> Tensor:
     if self_placement.is_shard() or self_placement.is_partial():
         placements = [_Partial(ReduceOp.SUM)]
         # partial reduce
-        partial_sum = Tensor.from_local(local_sum, device_mesh, placements)
+        partial_sum = DTensor.from_local(local_sum, device_mesh, placements)
         # all_reduce across device
         replicate_placements = [Replicate()]
         return partial_sum.redistribute(device_mesh, replicate_placements)
     elif self_placement.is_replicate():
-        return Tensor.from_local(
+        return DTensor.from_local(
             local_sum, device_mesh=device_mesh, placements=self.placements
         )
     else:

--- a/spmd/tensor/ops/matrix_ops.py
+++ b/spmd/tensor/ops/matrix_ops.py
@@ -2,7 +2,7 @@
 # implement matrix related ops for distributed tensor
 import torch.utils._pytree as pytree
 from torch.distributed.distributed_c10d import ReduceOp
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 from spmd.tensor.placement_types import Shard, Replicate, _Partial
 from spmd.tensor.ops.utils import (
     unwrap_local_tensor,
@@ -13,14 +13,14 @@ from spmd.tensor.ops.utils import (
 
 @register_impl("aten.addmm.default")
 def dist_addmm(
-    input: Tensor,
-    mat1: Tensor,
-    mat2: Tensor,
+    input: DTensor,
+    mat1: DTensor,
+    mat2: DTensor,
     # pyre-fixme[2]: Parameter must be annotated.
     beta=1,
     # pyre-fixme[2]: Parameter must be annotated.
     alpha=1,
-) -> Tensor:
+) -> DTensor:
     # dist addmm:
     # input:shard(0)    mat1: shard(0),  mat2: replicate
     # input:shard(1)    mat1: replicate, mat2: shard(1)
@@ -43,17 +43,17 @@ def dist_addmm(
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return Tensor.from_local(local_res, device_mesh, mat1.placements)
+        return DTensor.from_local(local_res, device_mesh, mat1.placements)
     elif mat1_placement.is_replicate() and mat2_placement.is_shard(dim=1):
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return Tensor.from_local(local_res, device_mesh, mat2.placements)
+        return DTensor.from_local(local_res, device_mesh, mat2.placements)
     elif mat1_placement.is_replicate() and mat2_placement.is_replicate():
         local_res = local_input.addmm(
             local_mat1, local_mat2, beta=beta, alpha=alpha
         )
-        return Tensor.from_local(
+        return DTensor.from_local(
             local_res, device_mesh, mat1.placements, run_check=False
         )
     else:
@@ -63,7 +63,7 @@ def dist_addmm(
 
 
 @register_impl("aten.mm.default")
-def dist_mm(mat1: Tensor, mat2: Tensor) -> Tensor:
+def dist_mm(mat1: DTensor, mat2: DTensor) -> DTensor:
     # dist mm:
     # mat1: shard(0),  mat2: replicate
     # mat1: replicate, mat2: shard(1)
@@ -79,14 +79,14 @@ def dist_mm(mat1: Tensor, mat2: Tensor) -> Tensor:
     # TODO: implement all combinations
     if mat1_placement.is_shard(dim=0) and mat2_placement.is_replicate():
         local_res = local_mat1.mm(local_mat2)
-        return Tensor.from_local(local_res, device_mesh, mat1.placements)
+        return DTensor.from_local(local_res, device_mesh, mat1.placements)
     elif mat1_placement.is_replicate() and mat2_placement.is_shard(dim=1):
         local_res = local_mat1.mm(local_mat2)
-        return Tensor.from_local(local_res, device_mesh, mat2.placements)
+        return DTensor.from_local(local_res, device_mesh, mat2.placements)
     elif mat1_placement.is_shard(dim=1) and mat2_placement.is_shard(dim=0):
         local_res = local_mat1.mm(local_mat2)
         placements = [_Partial(ReduceOp.SUM)]
-        partial_sum = Tensor.from_local(local_res, device_mesh, placements)
+        partial_sum = DTensor.from_local(local_res, device_mesh, placements)
         # all reduce across ranks
         replicate_placements = [Replicate()]
         return partial_sum.redistribute(device_mesh, replicate_placements)
@@ -95,7 +95,7 @@ def dist_mm(mat1: Tensor, mat2: Tensor) -> Tensor:
 
 
 @register_impl("aten.t.default")
-def dist_t(self: Tensor) -> Tensor:
+def dist_t(self: DTensor) -> DTensor:
     # transpose with sharding
     local_mat = pytree.tree_map(unwrap_local_tensor, self)
     assert local_mat.ndim == 2
@@ -104,6 +104,6 @@ def dist_t(self: Tensor) -> Tensor:
     device_mesh = self.device_mesh
 
     new_shard_dim = 1 if mat_placement.is_shard(dim=0) else 0
-    return Tensor.from_local(
+    return DTensor.from_local(
         transposed_local_mat, device_mesh, [Shard(new_shard_dim)]
     )

--- a/spmd/tensor/ops/tensor_ops.py
+++ b/spmd/tensor/ops/tensor_ops.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 from spmd.tensor.ops.utils import register_impl
 
 
@@ -10,8 +10,8 @@ from spmd.tensor.ops.utils import register_impl
 def dist_detach(self):
     device_mesh = self.device_mesh
 
-    detached_tensor = self.local_tensor().detach()
-    return Tensor.from_local(detached_tensor, device_mesh, self.placements)
+    detached_tensor = self.to_local().detach()
+    return DTensor.from_local(detached_tensor, device_mesh, self.placements)
 
 
 @register_impl("aten.ones_like.default")
@@ -32,8 +32,8 @@ def dist_ones_like(
 ):
     device_mesh = self.device_mesh
 
-    new_local_tensor = torch.ones_like(self.local_tensor())
-    return Tensor.from_local(new_local_tensor, device_mesh, self.placements)
+    new_local_tensor = torch.ones_like(self.to_local())
+    return DTensor.from_local(new_local_tensor, device_mesh, self.placements)
 
 
 # @register_impl("aten.expand.default")
@@ -41,5 +41,5 @@ def dist_ones_like(
 #     self_tensor = args[0]
 #     device_mesh = self_tensor.device_mesh
 
-#     new_local_tensor = torch.ones_like(self_tensor.local_tensor())
-#     return Tensor.from_local(new_local_tensor, device_mesh, self_tensor.placements)
+#     new_local_tensor = torch.ones_like(self_tensor.to_local())
+#     return DTensor.from_local(new_local_tensor, device_mesh, self_tensor.placements)

--- a/spmd/tensor/ops/tp_sharding_ops.py
+++ b/spmd/tensor/ops/tp_sharding_ops.py
@@ -5,7 +5,7 @@ import math
 import torch
 import torch.utils._pytree as pytree
 from typing import List
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 from spmd.tensor.placement_types import Shard
 from spmd.tensor.ops.utils import (
     unwrap_local_tensor,
@@ -17,13 +17,13 @@ from spmd.tensor.ops.utils import (
 The ops below were quickly hacked and needed to be polished down the road.
 Although they come with unit tests already, the logic is directly borrowed
 from ShardedTensor. We need to also make it work for all placement types 
-of Distributed Tensor and all corner cases for sharded distributed tensor.
+of DTensor and all corner cases for sharded distributed tensor.
 """
 
 
 @register_impl("aten.view.default")
 # pyre-fixme[2]: Parameter must be annotated.
-def dist_view(self: Tensor, *shape) -> Tensor:
+def dist_view(self: DTensor, *shape) -> DTensor:
     shape = shape[0]
     try:
         infer_idx = shape.index(-1)
@@ -65,13 +65,13 @@ def dist_view(self: Tensor, *shape) -> Tensor:
         *shape[sharding_dim + 1 :],
     )
     new_local_tensor = local_mat.view(*new_local_tensor_size)
-    return Tensor.from_local(
+    return DTensor.from_local(
         new_local_tensor, self.device_mesh, self.placements
     )
 
 
 @register_impl("aten.transpose.int")
-def dist_transpose(self: Tensor, dim0: int, dim1: int) -> Tensor:
+def dist_transpose(self: DTensor, dim0: int, dim1: int) -> DTensor:
     local_mat = pytree.tree_map(unwrap_local_tensor, self)
     mat_placement = pytree.tree_map(unwrap_single_placement, self)
     device_mesh = self.device_mesh
@@ -81,42 +81,42 @@ def dist_transpose(self: Tensor, dim0: int, dim1: int) -> Tensor:
     new_shard_dim = dim0 if mat_placement.is_shard(dim=dim1) else new_shard_dim
     new_sharding_placement = [Shard(new_shard_dim)]
     local_tensor = local_mat.transpose(dim0, dim1)
-    return Tensor.from_local(local_tensor, device_mesh, new_sharding_placement)
+    return DTensor.from_local(local_tensor, device_mesh, new_sharding_placement)
 
 
 @register_impl("aten.baddbmm.default")
 def dist_baddbmm(
-    self: Tensor,
-    batch1: Tensor,
-    batch2: Tensor,
+    self: DTensor,
+    batch1: DTensor,
+    batch2: DTensor,
     beta: float = 1.0,
     alpha: float = 1.0,
-) -> Tensor:
+) -> DTensor:
     local_input, local_batch1, local_batch2 = pytree.tree_map(
         unwrap_local_tensor, (self, batch1, batch2)
     )
     local_tensor = torch.ops.aten.baddbmm(
         local_input, local_batch1, local_batch2, beta=beta, alpha=alpha
     )
-    return Tensor.from_local(local_tensor, self.device_mesh, self.placements)
+    return DTensor.from_local(local_tensor, self.device_mesh, self.placements)
 
 
 @register_impl("aten.bmm.default")
-def dist_bmm(self: Tensor, mat2: Tensor) -> Tensor:
+def dist_bmm(self: DTensor, mat2: DTensor) -> DTensor:
     local_input, local_mat2 = pytree.tree_map(unwrap_local_tensor, (self, mat2))
     local_tensor = torch.ops.aten.bmm(local_input, local_mat2)
-    return Tensor.from_local(local_tensor, self.device_mesh, self.placements)
+    return DTensor.from_local(local_tensor, self.device_mesh, self.placements)
 
 
 @register_impl("aten._softmax.default")
-def dist_softmax(self: Tensor, dim: int, half_to_float: bool) -> Tensor:
+def dist_softmax(self: DTensor, dim: int, half_to_float: bool) -> DTensor:
     local_input = pytree.tree_map(unwrap_local_tensor, (self))
     local_tensor = local_input.softmax(dim=dim)
-    return Tensor.from_local(local_tensor, self.device_mesh, self.placements)
+    return DTensor.from_local(local_tensor, self.device_mesh, self.placements)
 
 
 @register_impl("aten.permute.default")
-def dist_permute(self: Tensor, dims: List[int]) -> Tensor:
+def dist_permute(self: DTensor, dims: List[int]) -> DTensor:
     local_mat = pytree.tree_map(unwrap_local_tensor, self)
     mat_placement = pytree.tree_map(unwrap_single_placement, self)
 
@@ -124,23 +124,23 @@ def dist_permute(self: Tensor, dims: List[int]) -> Tensor:
     new_sharding_dim = dims.index(sharding_dim)
     new_sharding_placement = [Shard(new_sharding_dim)]
     local_tensor = torch.ops.aten.permute(local_mat, dims=dims)
-    return Tensor.from_local(
+    return DTensor.from_local(
         local_tensor, self.device_mesh, new_sharding_placement
     )
 
 
 @register_impl("aten.cat.default")
-def dist_cat(tensor_list: List[Tensor], dim: int = 0) -> Tensor:
+def dist_cat(tensor_list: List[DTensor], dim: int = 0) -> DTensor:
     local_inputs = pytree.tree_map(unwrap_local_tensor, tensor_list)
     local_tensor = torch.ops.aten.concat(local_inputs, dim=dim)
-    return Tensor.from_local(
+    return DTensor.from_local(
         local_tensor, tensor_list[0].device_mesh, tensor_list[0].placements
     )
 
 
 @register_impl("aten.split.Tensor")
 # pyre-fixme[2]: Parameter must be annotated.
-def dist_split(self: Tensor, split_size_or_sections, dim=0) -> List[Tensor]:
+def dist_split(self: DTensor, split_size_or_sections, dim=0) -> List[DTensor]:
     local_mat = pytree.tree_map(unwrap_local_tensor, self)
     mat_placement = pytree.tree_map(unwrap_single_placement, self)
     sharding_dim = mat_placement.dim
@@ -156,15 +156,15 @@ def dist_split(self: Tensor, split_size_or_sections, dim=0) -> List[Tensor]:
             split_size_or_sections //= world_size
     tensor_list = local_mat.split(split_size_or_sections, dim=dim)
     return [
-        Tensor.from_local(tensor, self.device_mesh, [mat_placement])
+        DTensor.from_local(tensor, self.device_mesh, [mat_placement])
         for tensor in tensor_list
     ]
 
 
 @register_impl("contiguous")
 # pyre-fixme[2]: Parameter must be annotated.
-def dist_contiguous(self) -> "Tensor":
-    return Tensor.from_local(
+def dist_contiguous(self) -> "DTensor":
+    return DTensor.from_local(
         self._local_tensor.contiguous(), self.device_mesh, self.placements
     )
 
@@ -172,4 +172,4 @@ def dist_contiguous(self) -> "Tensor":
 @register_impl("is_contiguous")
 # pyre-fixme[2]: Parameter must be annotated.
 def dist_is_contiguous(self) -> bool:
-    return self.local_tensor().is_contiguous()
+    return self.to_local().is_contiguous()

--- a/spmd/tensor/ops/utils.py
+++ b/spmd/tensor/ops/utils.py
@@ -1,11 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from spmd.tensor.api import Tensor
+from spmd.tensor.api import DTensor
 
 
 # pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
 def unwrap_single_placement(e):
-    if not isinstance(e, Tensor):
+    if not isinstance(e, DTensor):
         return None
     assert len(e.placements) == 1, "more than one placement!"
     return e.placements[0]
@@ -14,9 +14,9 @@ def unwrap_single_placement(e):
 # pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
 def unwrap_local_tensor(e):
-    if not isinstance(e, Tensor):
+    if not isinstance(e, DTensor):
         return None
-    return e.local_tensor()
+    return e.to_local()
 
 
 # convenient wrapper to register functions
@@ -27,7 +27,7 @@ def register_impl(func):
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def wrapper(impl):
-        Tensor._dist_tensor_dispatch_ops[func] = impl
+        DTensor._dist_tensor_dispatch_ops[func] = impl
         return impl
 
     return wrapper

--- a/spmd/tensor/redistribute.py
+++ b/spmd/tensor/redistribute.py
@@ -8,12 +8,12 @@ from spmd.tensor.device_mesh import DeviceMesh
 
 
 def redistribute_spmd_tensor(
-    input: "spmd_tensor.Tensor",
+    input: "spmd_tensor.DTensor",
     device_mesh: DeviceMesh,
     placements: List[Placement],
-) -> "spmd_tensor.Tensor":
+) -> "spmd_tensor.DTensor":
     current_placements = input.placements
-    local_tensor = input.local_tensor()
+    local_tensor = input.to_local()
     if input.device_mesh != device_mesh:
         # TODO: alltoall reshuffling to change device_mesh if they are not the same
         raise NotImplementedError("Cross device mesh comm not supported yet!")
@@ -89,7 +89,7 @@ def redistribute_spmd_tensor(
 
     assert new_local_tensor is not None, "redistribute failed!"
 
-    return spmd_tensor.Tensor.from_local(
+    return spmd_tensor.DTensor.from_local(
         new_local_tensor, device_mesh, placements
     )
 
@@ -99,7 +99,7 @@ class Redistribute(torch.autograd.Function):
     def forward(  # type: ignore
         # pyre-fixme[2]: Parameter must be annotated.
         ctx,
-        input: "spmd_tensor.Tensor",
+        input: "spmd_tensor.DTensor",
         device_mesh: DeviceMesh,
         placements: List[Placement],
     ):
@@ -108,7 +108,7 @@ class Redistribute(torch.autograd.Function):
         return redistribute_spmd_tensor(input, device_mesh, placements)
 
     @staticmethod
-    def backward(ctx, grad_output: "spmd_tensor.Tensor"):  # type: ignore
+    def backward(ctx, grad_output: "spmd_tensor.DTensor"):  # type: ignore
         previous_placement = ctx.previous_placement
         previous_device_mesh = ctx.previous_device_mesh
         return (

--- a/spmd/tensor/utils.py
+++ b/spmd/tensor/utils.py
@@ -1,5 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-# from .api import Tensor
 
 
 # pyre-fixme[3]: Return type must be annotated.

--- a/test/spmd/tensor/demo.py
+++ b/test/spmd/tensor/demo.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import os
 import torch
-from spmd.tensor import Tensor, DeviceMesh, Shard, Replicate
+from spmd.tensor import DTensor, DeviceMesh, Shard, Replicate
 
 
 def synthetic_data(w, b, num_examples):
@@ -36,7 +36,7 @@ def main():
     print(f"rank = {rank}, true_w = {true_w}, true_b = {true_b}")
 
     # model params, replicated to all ranks with `placements=[Replicate()]`
-    w = spmd.Tensor(
+    w = spmd.DTensor(
         [[100.0], [100.0]],
         requires_grad=True,
         device_mesh=mesh,
@@ -52,12 +52,12 @@ def main():
     for epoch in range(num_epochs):
         for i in range(num_iters):
             # X, y are local tensors, we need to create distributed tensor from local
-            # torch.Tensor, and use DistributedTensor as model input to implement data parallel
+            # torch.Tensor, and use DTensor as model input to implement data parallel
             X, y = synthetic_data(true_w, true_b, batch_size)
-            g_X = Tensor.from_local(
+            g_X = DTensor.from_local(
                 x, device_mesh=mesh, placements=shard_0_placement
             )
-            g_y = Tensor.from_local(
+            g_y = DTensor.from_local(
                 y, device_mesh=mesh, placements=shard_0_placement
             )
             l = loss_func(model(g_X, w, b), g_y)

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -9,7 +9,7 @@ from torch.distributed.distributed_c10d import (
 )
 from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms
-from spmd.tensor import DeviceMesh, Tensor, Shard, Replicate
+from spmd.tensor import DeviceMesh, DTensor, Shard, Replicate
 
 
 class DeviceMeshTest(DistTensorTestBase):
@@ -26,10 +26,10 @@ class DeviceMeshTest(DistTensorTestBase):
         # should automatically convert the dist tensor to cuda
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.device.type, self.device_type)
         self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
+            dist_tensor.to_local().device.type, self.device_type
         )
 
     @with_comms
@@ -37,14 +37,14 @@ class DeviceMeshTest(DistTensorTestBase):
         with DeviceMesh(self.device_type, list(range(self.world_size))) as mesh:
             shard_spec = [Shard(0)]
             local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(
+            sharded_tensor = DTensor.from_local(
                 local_tensor, device_mesh=mesh, placements=shard_spec
             )
 
         with DeviceMesh(self.device_type, list(range(self.world_size))):
             shard_spec = [Shard(0)]
             local_tensor = torch.randn(3, 3)
-            sharded_tensor = Tensor.from_local(
+            sharded_tensor = DTensor.from_local(
                 local_tensor, placements=shard_spec
             )
             replica_spec = [Replicate()]
@@ -83,18 +83,18 @@ class DeviceMeshTest(DistTensorTestBase):
         # construct a dist tensor on 2d device mesh and test if works
         shard_spec = [Shard(0), Shard(1)]
         local_tensor = torch.randn(3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
         self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
+            dist_tensor.to_local().device.type, self.device_type
         )
 
         # if shard on the same tensor dimension
         # we should correctly construct the global tensor size
         shard_same_dim_spec = [Shard(0), Shard(0)]
         local_tensor = torch.randn(3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_same_dim_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_same_dim_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3]))
 
     @with_comms
@@ -133,11 +133,11 @@ class DeviceMeshTest(DistTensorTestBase):
         # construct a dist tensor on 2d device mesh and test if works
         shard_spec = [Shard(0), Shard(1)]
         local_tensor = torch.randn(3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
         self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
+            dist_tensor.to_local().device.type, self.device_type
         )
 
     @with_comms
@@ -168,21 +168,21 @@ class DeviceMeshTest(DistTensorTestBase):
         # construct a dist tensor on 3d device mesh and test if works
         shard_spec = [Shard(0), Shard(1), Shard(2)]
         local_tensor = torch.randn(3, 3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
         self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
+            dist_tensor.to_local().device.type, self.device_type
         )
 
         # construct a dist tensor on 3d device mesh with some shards on same dim
         shard_spec = [Shard(0), Shard(0), Shard(2)]
         local_tensor = torch.randn(3, 3, 3)
-        dist_tensor = Tensor.from_local(local_tensor, mesh, shard_spec)
+        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
         self.assertEqual(
-            dist_tensor.local_tensor().device.type, self.device_type
+            dist_tensor.to_local().device.type, self.device_type
         )
 
 

--- a/test/spmd/tensor/test_device_mesh.py
+++ b/test/spmd/tensor/test_device_mesh.py
@@ -28,9 +28,7 @@ class DeviceMeshTest(DistTensorTestBase):
         local_tensor = torch.randn(3, 3)
         dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.to_local().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.to_local().device.type, self.device_type)
 
     @with_comms
     def test_device_mesh_context_manager(self):
@@ -86,15 +84,15 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.to_local().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.to_local().device.type, self.device_type)
 
         # if shard on the same tensor dimension
         # we should correctly construct the global tensor size
         shard_same_dim_spec = [Shard(0), Shard(0)]
         local_tensor = torch.randn(3, 3)
-        dist_tensor = DTensor.from_local(local_tensor, mesh, shard_same_dim_spec)
+        dist_tensor = DTensor.from_local(
+            local_tensor, mesh, shard_same_dim_spec
+        )
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3]))
 
     @with_comms
@@ -136,9 +134,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.to_local().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.to_local().device.type, self.device_type)
 
     @with_comms
     def test_device_mesh_nd(self):
@@ -171,9 +167,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([6, 6, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.to_local().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.to_local().device.type, self.device_type)
 
         # construct a dist tensor on 3d device mesh with some shards on same dim
         shard_spec = [Shard(0), Shard(0), Shard(2)]
@@ -181,9 +175,7 @@ class DeviceMeshTest(DistTensorTestBase):
         dist_tensor = DTensor.from_local(local_tensor, mesh, shard_spec)
         self.assertEqual(dist_tensor.size(), torch.Size([12, 3, 6]))
         self.assertEqual(dist_tensor.device.type, self.device_type)
-        self.assertEqual(
-            dist_tensor.to_local().device.type, self.device_type
-        )
+        self.assertEqual(dist_tensor.to_local().device.type, self.device_type)
 
 
 class DeviceMeshCollectiveTest(DistTensorTestBase):

--- a/test/spmd/tensor/test_elementwise_ops.py
+++ b/test/spmd/tensor/test_elementwise_ops.py
@@ -2,7 +2,7 @@
 import torch
 from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms, TEST_GPU_NUM
-from spmd import DeviceMesh, Tensor, Shard, Replicate, _Partial
+from spmd import DeviceMesh, DTensor, Shard, Replicate, _Partial
 from torch.distributed.distributed_c10d import ReduceOp
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 
@@ -16,13 +16,13 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         input_tensor = torch.randn(*input_size, requires_grad=True).cuda(
             self.rank
         )
-        dist_tensor = Tensor.from_local(input_tensor, mesh, spec)
+        dist_tensor = DTensor.from_local(input_tensor, mesh, spec)
         reset_seed() if reset_seed else None
         dt = op(dist_tensor, **kwargs)
         reset_seed() if reset_seed else None
         expected = op(input_tensor, **kwargs)
-        self.assertEqual(input_tensor, dist_tensor.local_tensor())
-        self.assertEqual(expected, dt.local_tensor())
+        self.assertEqual(input_tensor, dist_tensor.to_local())
+        self.assertEqual(expected, dt.to_local())
 
     @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)

--- a/test/spmd/tensor/test_math_ops.py
+++ b/test/spmd/tensor/test_math_ops.py
@@ -16,7 +16,7 @@ class DistMathOpsTest(DistTensorTestBase):
         sumed_tensor = tensor_to_sum.sum()
         mat1 = distribute_tensor(tensor_to_sum, device_mesh, shard_spec)
         dt_sum = mat1.sum()
-        self.assertEqual(dt_sum.local_tensor(), sumed_tensor)
+        self.assertEqual(dt_sum.to_local(), sumed_tensor)
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_matrix_ops.py
+++ b/test/spmd/tensor/test_matrix_ops.py
@@ -24,7 +24,7 @@ class DistMatrixOpsTest(DistTensorTestBase):
             input_tensor, tensor_to_shard, tensor_to_replicate
         )
         self.assertEqual(
-            dist_res.redistribute(device_mesh, replica_spec).local_tensor(),
+            dist_res.redistribute(device_mesh, replica_spec).to_local(),
             local_res,
         )
 
@@ -42,7 +42,7 @@ class DistMatrixOpsTest(DistTensorTestBase):
         dist_res = torch.mm(mat1, mat2)
         local_res = torch.mm(tensor_to_shard, tensor_to_replicate)
         self.assertEqual(
-            dist_res.redistribute(device_mesh, replica_spec).local_tensor(),
+            dist_res.redistribute(device_mesh, replica_spec).to_local(),
             local_res,
         )
 

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -109,9 +109,7 @@ class RedistributeTest(DistTensorTestBase):
             device_mesh, replica_spec
         )
         self.assertEqual(partial_tensor.size(), partial_local.size())
-        self.assertEqual(
-            partial_local * 4, global_partial_tensor.to_local()
-        )
+        self.assertEqual(partial_local * 4, global_partial_tensor.to_local())
 
     @with_comms
     def test_partial_to_shard_0(self):
@@ -129,9 +127,7 @@ class RedistributeTest(DistTensorTestBase):
         )
         self.assertEqual(scatter_shard_tensor.size(), partial_tensor.size())
         self.assertEqual(scatter_shard_tensor.placements, shard_spec)
-        self.assertEqual(
-            scatter_shard_tensor.to_local(), torch.ones(3, 3) * 4
-        )
+        self.assertEqual(scatter_shard_tensor.to_local(), torch.ones(3, 3) * 4)
 
     @with_comms
     def test_partial_to_shard_1(self):
@@ -149,9 +145,7 @@ class RedistributeTest(DistTensorTestBase):
         )
         self.assertEqual(scatter_shard_tensor.size(), partial_tensor.size())
         self.assertEqual(scatter_shard_tensor.placements, shard1_spec)
-        self.assertEqual(
-            scatter_shard_tensor.to_local(), torch.ones(4, 3) * 4
-        )
+        self.assertEqual(scatter_shard_tensor.to_local(), torch.ones(4, 3) * 4)
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -6,7 +6,7 @@ from torch.distributed.distributed_c10d import ReduceOp
 from torch.testing._internal.common_utils import run_tests
 
 from ..test_utils import DistTensorTestBase, with_comms
-from spmd.tensor import DeviceMesh, Tensor, Replicate, Shard, _Partial
+from spmd.tensor import DeviceMesh, DTensor, Replicate, Shard, _Partial
 
 
 class RedistributeTest(DistTensorTestBase):
@@ -21,23 +21,23 @@ class RedistributeTest(DistTensorTestBase):
         chunked_list = expected_tensor.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
-        sharded_tensor = Tensor.from_local(
+        sharded_tensor = DTensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
         global_sharded_tensor = sharded_tensor.redistribute(
             device_mesh, replica_spec
         )
         self.assertEqual(global_sharded_tensor.size(), torch.Size([12, 3]))
-        self.assertEqual(expected_tensor, global_sharded_tensor.local_tensor())
+        self.assertEqual(expected_tensor, global_sharded_tensor.to_local())
 
         # 2) test shard -> replicate backward:
         # should give gradient as shard
         local_grad = torch.ones(12, 3)
-        grad_output = Tensor.from_local(local_grad, device_mesh, replica_spec)
+        grad_output = DTensor.from_local(local_grad, device_mesh, replica_spec)
         global_sharded_tensor.backward(grad_output)
         grad_input = sharded_tensor.grad
         self.assertEqual(grad_input.placements, shard_spec)
-        self.assertEqual(grad_input.local_tensor(), torch.ones(3, 3))
+        self.assertEqual(grad_input.to_local(), torch.ones(3, 3))
 
     @with_comms
     def test_replicate_to_replicate_forward_backward(self):
@@ -45,7 +45,7 @@ class RedistributeTest(DistTensorTestBase):
         replica_spec = [Replicate()]
         local_tensor = torch.randn(12, 3, requires_grad=True)
         # 1) test replicate -> replicate forward
-        replica_tensor = Tensor.from_local(
+        replica_tensor = DTensor.from_local(
             local_tensor, device_mesh, replica_spec
         )
         global_replica_tensor = replica_tensor.redistribute(
@@ -57,11 +57,11 @@ class RedistributeTest(DistTensorTestBase):
         # 2) test replicate -> replicate backward:
         # should give gradient as replicate
         local_grad = torch.ones(12, 3)
-        grad_output = Tensor.from_local(local_grad, device_mesh, replica_spec)
+        grad_output = DTensor.from_local(local_grad, device_mesh, replica_spec)
         global_replica_tensor.backward(grad_output)
         grad_input = replica_tensor.grad
         self.assertEqual(grad_input.placements, replica_spec)
-        self.assertEqual(grad_input.local_tensor(), local_grad)
+        self.assertEqual(grad_input.to_local(), local_grad)
 
     @with_comms
     def test_replicate_to_shard_forward_backward(self):
@@ -74,22 +74,22 @@ class RedistributeTest(DistTensorTestBase):
         chunked_list = local_replica.chunk(self.world_size, shard_dim)
         # make local tensor as the element of the corresponding chunked list
         local_tensor = chunked_list[self.rank]
-        replica_tensor = Tensor.from_local(
+        replica_tensor = DTensor.from_local(
             local_replica, device_mesh, replica_spec
         )
         reshard_tensor = replica_tensor.redistribute(device_mesh, shard_spec)
         self.assertEqual(reshard_tensor.size(), replica_tensor.size())
         self.assertEqual(reshard_tensor.placements, shard_spec)
-        self.assertEqual(reshard_tensor.local_tensor(), local_tensor)
+        self.assertEqual(reshard_tensor.to_local(), local_tensor)
 
         # 2) test replicate -> shard backward:
         # should give gradient as replicate
         local_grad = torch.ones(3, 3)
-        grad_output = Tensor.from_local(local_grad, device_mesh, shard_spec)
+        grad_output = DTensor.from_local(local_grad, device_mesh, shard_spec)
         reshard_tensor.backward(grad_output)
         grad_input = replica_tensor.grad
         self.assertEqual(grad_input.placements, replica_spec)
-        self.assertEqual(grad_input.local_tensor(), torch.ones(12, 3))
+        self.assertEqual(grad_input.to_local(), torch.ones(12, 3))
 
     @with_comms
     def test_partial_to_replicate(self):
@@ -102,7 +102,7 @@ class RedistributeTest(DistTensorTestBase):
         partial_spec = [_Partial(ReduceOp.SUM)]
         replica_spec = [Replicate()]
         # test partial -> replicate, which trigger all_reduce
-        partial_tensor = Tensor.from_local(
+        partial_tensor = DTensor.from_local(
             partial_local, device_mesh, partial_spec
         )
         global_partial_tensor = partial_tensor.redistribute(
@@ -110,7 +110,7 @@ class RedistributeTest(DistTensorTestBase):
         )
         self.assertEqual(partial_tensor.size(), partial_local.size())
         self.assertEqual(
-            partial_local * 4, global_partial_tensor.local_tensor()
+            partial_local * 4, global_partial_tensor.to_local()
         )
 
     @with_comms
@@ -120,7 +120,7 @@ class RedistributeTest(DistTensorTestBase):
         shard_spec = [Shard(shard_dim)]
         partial_spec = [_Partial(ReduceOp.SUM)]
         partial_local = torch.ones(12, 3)
-        partial_tensor = Tensor.from_local(
+        partial_tensor = DTensor.from_local(
             partial_local, device_mesh, partial_spec
         )
         # test partial to shard 0, trigger reduce_scatter
@@ -130,7 +130,7 @@ class RedistributeTest(DistTensorTestBase):
         self.assertEqual(scatter_shard_tensor.size(), partial_tensor.size())
         self.assertEqual(scatter_shard_tensor.placements, shard_spec)
         self.assertEqual(
-            scatter_shard_tensor.local_tensor(), torch.ones(3, 3) * 4
+            scatter_shard_tensor.to_local(), torch.ones(3, 3) * 4
         )
 
     @with_comms
@@ -141,7 +141,7 @@ class RedistributeTest(DistTensorTestBase):
         partial_spec = [_Partial(ReduceOp.SUM)]
         partial_local = torch.ones(4, 12)
         # test partial to shard 1, trigger reduce_scatter
-        partial_tensor = Tensor.from_local(
+        partial_tensor = DTensor.from_local(
             partial_local, device_mesh, partial_spec
         )
         scatter_shard_tensor = partial_tensor.redistribute(
@@ -150,7 +150,7 @@ class RedistributeTest(DistTensorTestBase):
         self.assertEqual(scatter_shard_tensor.size(), partial_tensor.size())
         self.assertEqual(scatter_shard_tensor.placements, shard1_spec)
         self.assertEqual(
-            scatter_shard_tensor.local_tensor(), torch.ones(4, 3) * 4
+            scatter_shard_tensor.to_local(), torch.ones(4, 3) * 4
         )
 
 

--- a/test/spmd/tensor/test_tensor.py
+++ b/test/spmd/tensor/test_tensor.py
@@ -5,7 +5,7 @@ from torch.distributed.distributed_c10d import ReduceOp
 
 from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms
-from spmd.tensor import DeviceMesh, Tensor, Replicate, Shard, _Partial
+from spmd.tensor import DeviceMesh, DTensor, Replicate, Shard, _Partial
 
 
 class DistTensorTest(DistTensorTestBase):
@@ -28,17 +28,17 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
+        sharded_tensor = DTensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
         self.assertEqual(sharded_tensor.size(), torch.Size([12, 3]))
 
         replica_spec = [Replicate()]
-        ddp_tensor = Tensor.from_local(local_tensor, device_mesh, replica_spec)
+        ddp_tensor = DTensor.from_local(local_tensor, device_mesh, replica_spec)
         self.assertEqual(ddp_tensor.size(), local_tensor.size())
 
         partial_spec = [_Partial(ReduceOp.SUM)]
-        partial_tensor = Tensor.from_local(
+        partial_tensor = DTensor.from_local(
             local_tensor, device_mesh, partial_spec
         )
         self.assertEqual(partial_tensor.size(), local_tensor.size())
@@ -48,7 +48,7 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
+        sharded_tensor = DTensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
 
@@ -62,7 +62,7 @@ class DistTensorTest(DistTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
         local_tensor = torch.randn(3, 3)
-        sharded_tensor = Tensor.from_local(
+        sharded_tensor = DTensor.from_local(
             local_tensor, device_mesh, shard_spec
         )
         print(sharded_tensor.device)

--- a/test/spmd/tensor/test_tensor_ops.py
+++ b/test/spmd/tensor/test_tensor_ops.py
@@ -2,7 +2,7 @@
 import torch
 from torch.testing._internal.common_utils import run_tests
 from ..test_utils import DistTensorTestBase, with_comms
-from spmd import distribute_tensor, DeviceMesh, Tensor, Shard, Replicate
+from spmd import distribute_tensor, DeviceMesh, DTensor, Shard, Replicate
 
 
 class DistTensorOpsTest(DistTensorTestBase):
@@ -23,10 +23,10 @@ class DistTensorOpsTest(DistTensorTestBase):
         replica_spec = [Replicate()]
 
         input_tensor = torch.randn(4, 8, requires_grad=True)
-        dist_tensor = Tensor.from_local(input_tensor, device_mesh, shard_spec)
+        dist_tensor = DTensor.from_local(input_tensor, device_mesh, shard_spec)
         ones_like_dt = torch.ones_like(dist_tensor)
         ones_expected = torch.ones(4, 8)
-        self.assertEqual(ones_expected, ones_like_dt.local_tensor())
+        self.assertEqual(ones_expected, ones_like_dt.to_local())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
API rename:
1. rename Tensor to DTensor for us to use internally, we could choose later if we still need name alias on package level.
2. rename `local_tensor()` to `to_local()` as it aligns more with `from_local`