### PR TITLE
[DTensor] Add tests for sigmoid ops

### DIFF
--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -7,7 +7,7 @@ from spmd.tensor.placement_types import PlacementSpec
 """
 If set to true, __DEBUG_STRICT will fail when an op doesn't have a sharding rule registered.
 """
-_DEBUG_STRICT = True
+_DEBUG_STRICT = False
 
 
 # ATen op schemas could have Tensor, Tuple[Tensor] and List[Tensor], so output type sould

--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -6,7 +6,7 @@ from spmd.tensor.placement_types import PlacementSpec
 """
 If set to true, __DEBUG_STRICT will fail when an op doesn't have a sharding rule registered.
 """
-_DEBUG_STRICT = False
+_DEBUG_STRICT = True
 
 
 # ATen op schemas could have Tensor, Tuple[Tensor] and List[Tensor], so output type sould

--- a/spmd/tensor/ops/pointwise_ops.py
+++ b/spmd/tensor/ops/pointwise_ops.py
@@ -123,6 +123,7 @@ from spmd.tensor.ops.prop_rules import pointwise_prop
 pointwise_ops = [
     "aten.relu.default",
     "aten.gelu.default",
+    "aten.sigmoid.default",
 ]
 
 

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -41,6 +41,9 @@ class DistElementwiseOpsTest(DistTensorTestBase):
             device_mesh, [Replicate()], (8, 5), torch.nn.functional.relu
         )
         self._run_sharded_elementwise_ops(
+            device_mesh, [Shard(0)], (8, 5), torch.sigmoid
+        )
+        self._run_sharded_elementwise_ops(
             device_mesh, [Replicate()], (8, 5), torch.sigmoid
         )
 

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -39,6 +39,9 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         self._run_sharded_elementwise_ops(
             device_mesh, [Replicate()], (8, 5), torch.nn.functional.relu
         )
+        self._run_sharded_elementwise_ops(
+            device_mesh, [Replicate()], (8, 5), torch.sigmoid
+        )
 
     @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)


### PR DESCRIPTION
Added the following for checking sigmoid op coverage for DT:
1. Registered `aten.sigmoid.default` in list of supported pointwise ops
2. Added tests for 1-D mesh for replicate and shard specs.

Open questions:
1. Should we add tests for 2D since that is the more complex case? 
2. Do we need to add 1 shard and replicate for all pointwise ops or is there something more generic we can add?