### PR TITLE
Fix code returned from docker to GHA

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -208,7 +208,7 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           # Run GPU tests and return error signal from docker
-          docker exec -t -w "${PIPPY_ROOT}" "${container_name}" bash -c "bash .github/workflows/gpu_tests.sh; exit $?"
+          docker exec -t -w "${PIPPY_ROOT}" "${container_name}" bash -c "bash .github/workflows/gpu_tests.sh; exit \$?"
       - name: Chown workspace
         if: always()
         run: |

--- a/.github/workflows/gpu_tests.sh
+++ b/.github/workflows/gpu_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 # Print test options
 echo "VERBOSE: ${VERBOSE}"

--- a/.github/workflows/gpu_tests.sh
+++ b/.github/workflows/gpu_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -x
 
 # Print test options
 echo "VERBOSE: ${VERBOSE}"
@@ -29,6 +29,8 @@ pip3 install git+https://github.com/huggingface/transformers.git@main sentencepi
 
 # Install pippy
 python3 setup.py install
+
+set -ex
 
 # Run all integration tests
 python3 test/local_test_forward.py --replicate ${REPLICATE} -s ${SCHEDULE}

--- a/test/local_test_forward.py
+++ b/test/local_test_forward.py
@@ -118,6 +118,7 @@ def run_worker(rank, world_size, args):
                                               rpc_timeout=1800,
                                               _transports=tp_transports())
     if args.cuda:
+        raise NotImplementedError()
         n_devs = torch.cuda.device_count()
         if n_devs > 0:
             dev_id = rank % n_devs

--- a/test/local_test_forward.py
+++ b/test/local_test_forward.py
@@ -118,7 +118,6 @@ def run_worker(rank, world_size, args):
                                               rpc_timeout=1800,
                                               _transports=tp_transports())
     if args.cuda:
-        raise NotImplementedError()
         n_devs = torch.cuda.device_count()
         if n_devs > 0:
             dev_id = rank % n_devs


### PR DESCRIPTION
Previously, our GHA command has:
```
docker exec -t -w "${PIPPY_ROOT}" "${container_name}" bash -c "bash .github/workflows/gpu_tests.sh; exit $?"
```

`$?` was expanded at the GHA level rather than inside docker. Hence docker always do `exit 0`, hiding the error.

Adding a `\` before `$` to fix this issue.

Fixed #353 