### PR TITLE
Cancel CI on previous commit when a new commit is pushed

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -9,6 +9,11 @@ on:
       - 'docs/**'
       - '**.md'
 
+concurrency:
+  # Cancel CI on previous commit when a new commit is pushed to the same branch
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   pytest_tests:


### PR DESCRIPTION
Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time.

Reduce our CI load.

Reference:
https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre