### PR TITLE
Separate pippy and spmd CI and speed up spmd CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,7 +35,7 @@ jobs:
       run: mypy $(git ls-files '*.py' | grep -v pippy/fx | grep -v test/.*fx)
     - name: Lint with flake8
       if: always()
-      run: flake8 pippy
+      run: flake8 pippy spmd
     - name: Lint with black for SPMD
       if: always()
       run: black --check --line-length 80 spmd test/spmd

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -5,9 +5,12 @@ on:
     branches:
     - main
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
+    paths:
+      - 'pippy/**'
+      - 'test/**'
+      - '!test/spmd/**'
+      - '!docs/**'
+      - '!**.md'
 
 concurrency:
   # Cancel CI on previous commit when a new commit is pushed to the same branch

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -6,6 +6,7 @@ on:
     - main
   pull_request:
     paths:
+      - '.github/**'
       - 'pippy/**'
       - 'test/**'
       - '!test/spmd/**'

--- a/.github/workflows/spmd_tests.yaml
+++ b/.github/workflows/spmd_tests.yaml
@@ -6,6 +6,7 @@ on:
     - main
   pull_request:
     paths:
+      - '.github/**'
       - 'spmd/**'
       - 'test/spmd/**'
       - '!docs/**'

--- a/.github/workflows/spmd_tests.yaml
+++ b/.github/workflows/spmd_tests.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pytest-shard numpy
           if [ -f spmd/requirements_dev.txt ]; then pip install -r spmd/requirements_dev.txt; fi
           if [ -f spmd/requirements.txt ]; then pip install -r spmd/requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Test with pytest

--- a/.github/workflows/spmd_tests.yaml
+++ b/.github/workflows/spmd_tests.yaml
@@ -5,9 +5,11 @@ on:
     branches:
     - main
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
+    paths:
+      - 'spmd/**'
+      - 'test/spmd/**'
+      - '!docs/**'
+      - '!**.md'
 
 jobs:
 
@@ -16,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
+        shard: ["0", "1", "2", "3"]
     container:
       image: python:${{ matrix.python-version }}
 
@@ -28,4 +31,4 @@ jobs:
           if [ -f spmd/requirements.txt ]; then pip install -r spmd/requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Test with pytest
         run: |
-          pytest --cov=spmd test/spmd/
+          pytest --shard-id=${{ matrix.shard }} --num-shards=4 --cov=spmd test/spmd/


### PR DESCRIPTION
This PR separates SPMD CI job so that each PR in subproject could
run its own CI separately without interfering each other. This help
us save some resources and shorter waiting time on changes

This also change spmd tests to use shard to speed up testing