### PR TITLE
Do not run CI for previous commit if PR gets updated

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   # Cancel CI on previous commit when a new commit is pushed to the same branch
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   # Cancel CI on previous commit when a new commit is pushed to the same branch
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/spmd_tests.yaml
+++ b/.github/workflows/spmd_tests.yaml
@@ -12,6 +12,11 @@ on:
       - '!docs/**'
       - '!**.md'
 
+concurrency:
+  # Cancel CI on previous commit when a new commit is pushed to the same branch
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   pytest_tests:

--- a/.github/workflows/spmd_tests.yaml
+++ b/.github/workflows/spmd_tests.yaml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   # Cancel CI on previous commit when a new commit is pushed to the same branch
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If the same branch gets updated, we should cancel the CI for the previous push to save some resources.

Turns out that group: ${{ github.ref }} only works for one CI test script, we need to make it more detailed so that both PiPPy and spmd can use different groups here.