### PR TITLE
[spmd] add support for inplace op registration

### DIFF
--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -90,7 +90,9 @@ class OutputSharding:
 
 def is_inplace_op(op_call: torch._ops.OpOverload) -> bool:
     # util function to check if an op is inplace or not
-    # TODO: bind the core inplace op check to python
+    # TODO: This function is copied from ATen/BatchedFallback.cpp
+    # We should bind the inplace op check to schema python
+    # bindings directly.
     op_schema = op_call._schema
     if not op_schema.is_mutable or len(op_schema.returns) != 1:
         return False

--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -4,6 +4,7 @@ from typing import List, Callable, Dict, Tuple, Optional, cast
 
 import torch
 from torch.utils._pytree import tree_map
+from torchgen.model import FunctionSchema, SchemaKind
 
 import spmd.tensor.api as spmd_tensor
 from spmd.tensor.placement_types import DTensorSpec, OutputSpecType
@@ -13,6 +14,7 @@ from spmd.tensor.utils import (
     unwrap_schema,
     pack_args_kwargs_with_local_tensor,
 )
+
 
 """
 If set to true, __DEBUG_STRICT will fail when an op doesn't have a sharding rule registered.
@@ -88,27 +90,6 @@ class OutputSharding:
     failed_reason: Optional[str] = None
 
 
-def is_inplace_op(op_call: torch._ops.OpOverload) -> bool:
-    # util function to check if an op is inplace or not
-    # TODO: This function is copied from ATen/BatchedFallback.cpp
-    # We should bind the inplace op check to schema python
-    # bindings directly.
-    op_schema = op_call._schema
-    if not op_schema.is_mutable or len(op_schema.returns) != 1:
-        return False
-
-    alias_info = op_schema.arguments[0].alias_info
-    if alias_info is None or not alias_info.is_write:
-        return False
-
-    for arg in op_schema.arguments[1:]:
-        if arg.alias_info is not None:
-            return False
-
-    return_alias = op_schema.returns[0].alias_info
-    return return_alias and return_alias.is_write
-
-
 def operator_dispatch(
     op_call: torch._ops.OpOverload,
     args: Tuple[object, ...],
@@ -116,6 +97,9 @@ def operator_dispatch(
     op_to_rules: Dict[str, Callable[[OpSchema], OutputSharding]],
     custom_dispatch_ops: Dict[str, Callable[..., object]],
 ) -> object:
+
+    func_schema = FunctionSchema.parse(str(op_call._schema))
+    schema_kind = func_schema.kind()
 
     op_key = str(op_call)
     # STEP 0. See if threre're user defined custom aten operator
@@ -187,13 +171,24 @@ def operator_dispatch(
             **local_tensor_kwargs,
         )
 
-        if not is_inplace_op(op_call):
-            return wrap(local_results, output_sharding.output_spec)
-        else:
+        if schema_kind == SchemaKind.inplace:
             # inplace op should return self instead of re-wrapping
             self = cast(spmd_tensor.DTensor, args[0])
             self._spec = cast(DTensorSpec, output_sharding.output_spec)
             return self
+        elif schema_kind == SchemaKind.out:
+            # out variant could possibly have multiple out args (i.e. lu_unpack.out)
+            output_specs = (
+                (output_sharding.output_spec,)
+                if not isinstance(output_sharding.output_spec, tuple)
+                else output_sharding.output_spec
+            )
+            for i, out in enumerate(func_schema.arguments.out):
+                out_dt = cast(spmd_tensor.DTensor, kwargs[out.name])
+                out_dt._spec = cast(DTensorSpec, output_specs[i])
+
+        else:
+            return wrap(local_results, output_sharding.output_spec)
 
     else:
         # step 3. If there's not even one sharding rule

--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -188,7 +188,7 @@ def operator_dispatch(
         if not is_inplace_op(op_call):
             return wrap(local_results, output_sharding.output_spec)
         else:
-            # inplace op should return self instead of new wrappr
+            # inplace op should return self instead of re-wrapping
             self = cast(spmd_tensor.DTensor, args[0])
             self._spec = cast(DTensorSpec, output_sharding.output_spec)
             return self

--- a/spmd/tensor/ops/pointwise_ops.py
+++ b/spmd/tensor/ops/pointwise_ops.py
@@ -121,7 +121,9 @@ pointwise_ops = [
     "aten.relu.default",
     "aten.gelu.default",
     "aten.sigmoid.default",
+    "aten.add.out",
     "aten.add_.Scalar",
+    "aten.mul_.Scalar",
 ]
 
 

--- a/spmd/tensor/ops/pointwise_ops.py
+++ b/spmd/tensor/ops/pointwise_ops.py
@@ -121,6 +121,7 @@ pointwise_ops = [
     "aten.relu.default",
     "aten.gelu.default",
     "aten.sigmoid.default",
+    "aten.add_.Scalar",
 ]
 
 

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -21,7 +21,9 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         input_tensor = torch.randn(
             *input_size, device=self.device_type, requires_grad=True
         )
-        dist_tensor = DTensor(input_tensor, mesh, spec)
+        dist_tensor = DTensor(
+            input_tensor, mesh, spec, requires_grad=input_tensor.requires_grad
+        )
         reset_seed() if reset_seed else None
         dt = op(dist_tensor, **kwargs)
         reset_seed() if reset_seed else None

--- a/test/spmd/tensor/test_tensor_ops.py
+++ b/test/spmd/tensor/test_tensor_ops.py
@@ -54,10 +54,18 @@ class DistTensorOpsTest(DistTensorTestBase):
         self.assertEqual(tensor.grad, torch.ones(3, 5, 6))
 
     @with_comms
+    def test_inplace_op(self):
+        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        input_tensor = torch.randn((12, 3), device=self.device_type)
+        dist_tensor = distribute_tensor(input_tensor, mesh, [Shard(0)])
+        res = dist_tensor.add_(3)
+        # inplace op should be the same instance before and after
+        self.assertTrue(res is dist_tensor)
+
+    @with_comms
     def test_ones_like(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         shard_spec = [Shard(0)]
-        replica_spec = [Replicate()]
 
         input_tensor = torch.randn(4, 8, requires_grad=True)
         dist_tensor = DTensor.from_local(input_tensor, device_mesh, shard_spec)

--- a/test/spmd/tensor/test_tensor_ops.py
+++ b/test/spmd/tensor/test_tensor_ops.py
@@ -57,10 +57,29 @@ class DistTensorOpsTest(DistTensorTestBase):
     def test_inplace_op(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         input_tensor = torch.randn((12, 3), device=self.device_type)
-        dist_tensor = distribute_tensor(input_tensor, mesh, [Shard(0)])
-        res = dist_tensor.add_(3)
+        dt_to_add = distribute_tensor(input_tensor, mesh, [Shard(0)])
+        dt_to_mul = dt_to_add.clone()
+        expected_add_dt = dt_to_add.clone() + 3
+        add_res = dt_to_add.add_(3)
+        expected_mul_dt = dt_to_mul.clone() * 3
+        mul_res = dt_to_mul.mul_(3)
         # inplace op should be the same instance before and after
-        self.assertTrue(res is dist_tensor)
+        self.assertTrue(add_res is dt_to_add)
+        self.assertEqual(add_res.to_local(), expected_add_dt.to_local())
+
+        self.assertTrue(mul_res is dt_to_mul)
+        self.assertEqual(mul_res.to_local(), expected_mul_dt.to_local())
+
+    @with_comms
+    def test_op_out_variant(self):
+        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        input_tensor = torch.randn((12, 3), device=self.device_type)
+        dist_tensor_out = distribute_tensor(input_tensor, mesh, [Shard(0)])
+        expected_dt = dist_tensor_out.clone() + 3
+        res = torch.add(dist_tensor_out, 3, out=dist_tensor_out)
+        # op out variant should be the same instance before and after
+        self.assertTrue(res is dist_tensor_out)
+        self.assertEqual(dist_tensor_out.to_local(), expected_dt.to_local())
 
     @with_comms
     def test_ones_like(self):


### PR DESCRIPTION
inplace op should return self rather than being re-wrapped, also
add a simple aten.add_ op here to test inplace op semantic, for
add opertor itself we should test separately