### PR TITLE
Add driver process group setter

### DIFF
--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -20,7 +20,6 @@ from transformers.utils import (
 )
 from transformers.utils import torch_required, cached_property
 
-import pippy
 import pippy.hf.bart as bart
 import pippy.hf.bert as bert
 import pippy.hf.gpt2 as gpt2

--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -94,6 +94,17 @@ class PiPPyTrainingArguments(TrainingArguments):
     def device(self, value):
         self._device = value
 
+    # Process Group including all drivers
+    _driver_group = None
+
+    @property
+    def driver_group(self):
+        return self._driver_group
+
+    @driver_group.setter
+    def driver_group(self, value):
+        self._driver_group = value
+
     @cached_property
     @torch_required
     def _setup_devices(self) -> "torch.device":
@@ -152,7 +163,7 @@ class PiPPyTrainingArguments(TrainingArguments):
                     # elif is_sagemaker_dp_enabled():
                     #     dist.barrier()
                     # else:
-                    torch.distributed.barrier(group=pippy.utils.dp_pg_for_reference)
+                    torch.distributed.barrier(group=self.driver_group)
                 yield
             finally:
                 if is_main_process:
@@ -163,7 +174,7 @@ class PiPPyTrainingArguments(TrainingArguments):
                     # elif is_sagemaker_dp_enabled():
                     #     pass  # TODO dist.barrier()
                     # else:
-                    torch.distributed.barrier(group=pippy.utils.dp_pg_for_reference)
+                    torch.distributed.barrier(group=self.driver_group)
         else:
             yield
 

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -89,8 +89,7 @@ def run_worker(rank, run_master, args, *extra_args):
     pp_ranks_per_dp_group = [[i * args.dp_group_size + rank for i in range(args.pp_group_size)]
                              for rank in range(args.dp_group_size)]
 
-    global dp_pg_for_reference
-    dp_pg_for_reference = torch.distributed.new_group(list(range(args.dp_group_size)))
+    args.driver_group = torch.distributed.new_group(list(range(args.dp_group_size)))
 
     global exclude_master
     exclude_master = args.exclude_master if hasattr(args, 'exclude_master') else 0

--- a/test/local_test_ddp.py
+++ b/test/local_test_ddp.py
@@ -141,7 +141,8 @@ def run_master(pp_ranks, args):
         grad_value = rpc.rpc_sync(module_rref.owner(), get_grad_from_executor, (module_rref, param_qualname))
         pipe_grads[name] = copy.deepcopy(grad_value)
 
-    wrapper_ddp = torch.nn.parallel.DistributedDataParallel(wrapper, process_group=pippy.utils.dp_pg_for_reference)
+    # User driver group as the DDP reference group
+    wrapper_ddp = torch.nn.parallel.DistributedDataParallel(wrapper, process_group=args.driver_group)
 
     optim = torch.optim.SGD(wrapper_ddp.parameters(), lr=0.05)
     optim.zero_grad()


### PR DESCRIPTION
Fix #386 
For user using `PiPPySeq2SeqTrainingArguments` without `pippy.utils.run_pippy`
because `dp_pg_for_reference` is only defined in `run_pippy`