### PR TITLE
add _remove_gradient_tensor_clones

### DIFF
--- a/spmd/compiler/api.py
+++ b/spmd/compiler/api.py
@@ -20,6 +20,7 @@ from spmd.tensor.redistribute import _redistribute_with_local_tensor
 
 from .graph_utils import OP
 from .log_utils import rank0_info
+from .fusion import run_comm_fusion
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -313,6 +314,9 @@ def _convert_to_distributed(
             raise ValueError(f"Unrecognized node {node}")
 
     _rebuild_graph(gm, node_replacements)
+
+    if training_phase == TrainingPhase.BACKWARD:
+        gm = run_comm_fusion(gm)
 
     return make_boxed_func(gm)
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -18,8 +18,8 @@ from functools import partial
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-_debug = partial(rank0_debug, logger)
-_info = partial(rank0_info, logger)
+_debug = partial(rank0_debug, logger)  # type: ignore
+_info = partial(rank0_info, logger)  # type: ignore
 
 # enum for the supported fusion comm types
 class CommType(str, Enum):

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -12,7 +12,6 @@ from .graph_utils import (
     get_node_tensor_numel,
     get_output_node,
     graph_cleanup,
-    pretty_print_graph,
 )
 from .log_utils import rank0_debug, rank0_info
 from functools import partial
@@ -24,11 +23,11 @@ _info = partial(rank0_info, logger)
 
 # enum for the supported fusion comm types
 class CommType(str, Enum):
-    allreduce = "allreduce_"
-    allgather = "allgather_"
-    broadcast = "broadcast_"
-    reducescatter = "reduce_scatter_"
-    scatter = "scatter_"
+    allreduce: str = "allreduce_"
+    allgather: str = "allgather_"
+    broadcast: str = "broadcast_"
+    reducescatter: str = "reduce_scatter_"
+    scatter: str = "scatter_"
 
 
 @dataclass
@@ -167,7 +166,7 @@ def _scan_graph_for_fusion_elements(
 
 
 def _remove_gradient_tensor_clones(
-    gm: fx.GraphModule, comm_type=CommType.allreduce
+    gm: fx.GraphModule, comm_type: CommType = CommType.allreduce
 ) -> int:
     """
     Optimizes away any duplicate gradient tensor nodes from DTensor


### PR DESCRIPTION
This adds an initial optimization pass in fusion.py to remove any duplicate gradient tensor nodes created from the DTensor comm collective insertion.

It is a sequence matcher that locates the DTensor expansion signature, delinks the clone node, and remaps the comm collective tensor argument to the actual gradient tensor node.
After the pass, it then recompiles the graph to remove the duplicate gradient nodes and return an optimized graph with no redundant gradient clone nodes and a count of clone nodes removed.

This PR resolves this tracking issue:
https://github.com/pytorch/tau/issues/625
