### PR TITLE
Feature remove clones source

### DIFF
--- a/spmd/compiler/api.py
+++ b/spmd/compiler/api.py
@@ -185,8 +185,8 @@ def _remove_clone_tensor(subgm: fx.GraphModule) -> fx.GraphModule:
     """rewrite dummy add graph to remove clone of grad tensor"""
     nodemap = create_graph_node_map(subgm)
 
-    clone_node = nodemap["clone"]
-    comm_node = nodemap["allreduce__default"]
+    clone_node = nodemap.get("clone")
+    comm_node = nodemap.get("allreduce__default")
 
     assert comm_node is not None, "expected all_reduce comm node not present."
     assert clone_node is not None, "expected clone node not present."

--- a/spmd/compiler/api.py
+++ b/spmd/compiler/api.py
@@ -22,8 +22,8 @@ from .graph_utils import OP, create_graph_node_map
 from .log_utils import rank0_debug, rank0_info
 
 logger: logging.Logger = logging.getLogger(__name__)
-_debug = partial(rank0_debug, logger)
-_info = partial(rank0_info, logger)
+_debug = partial(rank0_debug, logger)  # type: ignore
+_info = partial(rank0_info, logger)  # type: ignore
 
 
 class TrainingPhase(Enum):

--- a/spmd/compiler/api.py
+++ b/spmd/compiler/api.py
@@ -188,8 +188,8 @@ def _remove_clone_tensor(subgm: fx.GraphModule) -> fx.GraphModule:
     clone_node = nodemap["clone"]
     comm_node = nodemap["allreduce__default"]
 
-    assert comm_node is not None, f"expected all_reduce comm node not present."
-    assert clone_node is not None, f"expected clone node not present."
+    assert comm_node is not None, "expected all_reduce comm node not present."
+    assert clone_node is not None, "expected clone node not present."
 
     grad_tensor_node = clone_node.args[0]
     comm_node.update_arg(0, [grad_tensor_node])

--- a/spmd/compiler/graph_utils.py
+++ b/spmd/compiler/graph_utils.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Optional
+from typing import Dict, Optional
 
 import torch.fx as fx
 
@@ -18,6 +18,14 @@ class OP(str, Enum):
     GET_ATTR = "get_attr"
     OUTPUT = "output"
     PLACEHOLDER = "placeholder"
+
+
+def create_graph_node_map(gm: fx.GraphModule) -> Dict[str, fx.Node]:
+    """utility to put graph module into a node map for easier adjustments"""
+    mapping = {}
+    for node in gm.graph.nodes:
+        mapping[node.name] = node
+    return mapping
 
 
 def get_node_tensor_numel(node: fx.Node) -> Optional[int]:


### PR DESCRIPTION
This is a second PR for removing the redundant gradient clone tensors, and approaches it differently than the first PR.   
(first one is https://github.com/pytorch/tau/pull/626)

This one effects the change closer to the source, by rewriting the subgraph produced from  _get_dtensor_dispatch_graph and inside dummy_add_graph.

It does this by adding a new function, _remove_clone_tensor() which rewrites the subgraph to bypass the clone node and then removes the clone. 
Thus, the graphs produced from SPMD do not have the redundant clones to start.
The one negative here is that each subgraph rewrite now requires it own recompile to cement the change, vs one final recompile in the earlier PR.  Not sure if recompiling multiple subgraphs is any more or less expensive vs one time full graph recompile. 
By contrast, the earlier PR cleaned the graphs by a direct pass through the entire finished graph. 

So two different approaches to resolving the same issue.
I think resolving closer to source is preferred, hence this second PR. 