### PR TITLE
Disable DDP bucket rebuild to avoid hang in ddp2pipe

### DIFF
--- a/examples/ddp2pipe/ddp2pipe.py
+++ b/examples/ddp2pipe/ddp2pipe.py
@@ -169,7 +169,12 @@ class FullModel(nn.Module):
         super().__init__()
         self.flatten = nn.Flatten()
         self.ddp_model = DDPModel().to(device)
-        self.ddp_model = DDP(self.ddp_model, find_unused_parameters=True, static_graph=False)
+        # The settings of find_unused_parameters and static_graph are added to avoid a hang related to a broadcast in
+        # the forward pass of DDP.  They disable DDP bucket rebuild hence disabling the broadcast.
+        self.ddp_model = DDP(self.ddp_model,
+                             find_unused_parameters=True,
+                             static_graph=False,
+                            )
 
         rank = torch.distributed.get_rank()
         dp_group_size = len(pp_ranks_per_dp_group)


### PR DESCRIPTION
Before this workaround, the ddp2pipe example hangs in a broadcast in the 2nd forward pass of the DDP arch.

The broadcast is needed for a bucket rebuild in DDP which is done after its 1st backward.

Adding flags:
```
find_unused_parameters=True
static_graph=False
```
can disable the bucket rebuild.

Ref per @mrshenli 👍 :
https://github.com/pytorch/pytorch/blob/6317311e61e0af62d633423de58abe1b2fe44176/torch/csrc/distributed/c10d/reducer.hpp#L130

Now we can run the ddp2pipe example on GPU without setting `TORCH_DISTRIBUTED_DEBUG=DETAIL`.

```
$ torchrun --nproc_per_node=4 ddp2pipe.py
...
100%|██████████| 250/250 [00:25<00:00, 10.52it/s]
```