### PR TITLE
Add VERSION_NO_GIT env to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ except Exception:
 
 if os.getenv("BUILD_VERSION"):
     version = os.getenv("BUILD_VERSION", version)
+elif os.getenv("VERSION_NO_GIT", "0") == "1":
+    pass
 elif sha != "Unknown":
     version += "+" + sha[:7]
 


### PR DESCRIPTION
## Description

By default, build version will come with Git SHA.

With this PR,
```
$ cd binaries
$ VERSION_NO_GIT=1 python build.py
```
can build wheels with formal version in `version.txt`.