### PR TITLE
fix loading opt models

### DIFF
--- a/examples/inference/hf_generate.py
+++ b/examples/inference/hf_generate.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     assert args.world_size % args.pp_group_size == 0
 
-    supported_model_categories = ["opt", "gpt2", "bloom", "EleutherAI/gpt", "codegen"]
+    supported_model_categories = ["opt", "gpt2", "bloom", "EleutherAI/gpt", "codegen", "GPT"]
     # For example:
     # "facebook/opt-350m"
     # "gpt2"

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -31,6 +31,8 @@ def load_checkpoint(
                 "word_embeddings.weight",
                 "shared.weight",
                 "wte.weight",
+                "decoder.embed_tokens.weight",
+                "encoder.embed_tokens.weight",
             ]:
                 if hasattr(model, "lm_head"):
                     model.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
@@ -84,12 +86,14 @@ def set_module_tensor_to_device(
     model_pipe_tensor_name = param_name.split(".")[-1]
     # Parameters in module
     normal_params = [
-        "transformer_" + model_pipe_module_name,
         model_pipe_module_name,
+        "model_" + model_pipe_module_name,
+        "transformer_" + model_pipe_module_name,
     ]
     # Parameters in module._parameters
     moved_params = [
         "moved_" + model_pipe_module_name,
+        "moved_model_" + model_pipe_module_name,
         "moved_transformer_" + model_pipe_module_name,
     ]
     tensor_name = None


### PR DESCRIPTION
Fixed loading opt models. The prefix of module names are different across models, so we need to consider different models in the loading module function. And I also add GPT to the support models
@kwen2501 @HamidShojanazeri Could you please review it? Thanks!