### PR TITLE
Load only necessary checkpoint files

### DIFF
--- a/examples/inference/hf_generate.py
+++ b/examples/inference/hf_generate.py
@@ -66,6 +66,7 @@ def run_all(pp_ranks, args):
         tracer=PiPPyHFTracer(),
         concrete_args=concrete_args,
         index_filename=args.index_filename,
+        checkpoint_prefix=args.checkpoint_prefix,
     )
 
     params = get_number_of_params(stage_mod)
@@ -103,6 +104,7 @@ if __name__ == "__main__":
     parser.add_argument('--pp_group_size', type=int, default=int(os.getenv("WORLD_SIZE", 4)))
     parser.add_argument('--dtype', type=str, default="fp32", choices=["fp32", "bf16", "fp16"])
     parser.add_argument('--index_filename', type=str, default=None, help="The director of model's index.json file")
+    parser.add_argument('--checkpoint_prefix', type=str, default=None, help="Prefix to add to the weight names in checkpoint map back to model structure")
 
     args = parser.parse_args()
 

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import operator
 from enum import Enum
+import os
 import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1082,7 +1083,13 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
     _stage_init_lock = threading.Lock()
     stage_init_cv = threading.Condition(_stage_init_lock)
 
-    def defer_stage_init(self, device, index_filename=None, dtype=None):
+    def defer_stage_init(
+        self,
+        device: torch.device,
+        index_filename: Union[str, os.PathLike] = None,
+        dtype: torch.dtype = None,
+        checkpoint_prefix: str = None,
+    ):
         def materialize_stage(target: str) -> torch.nn.Module:
             logging.info(f"Materializing {target} on {device}")
             submodule = self.split_gm.get_submodule(target)
@@ -1092,6 +1099,7 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
                     index_filename=index_filename,
                     device=device,
                     dtype=dtype,
+                    checkpoint_prefix=checkpoint_prefix,
                 )
             try:
                 submodule.to(device)

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -13,49 +13,57 @@ def load_checkpoint(
     index_filename: Union[str, os.PathLike],
     device: torch.device = None,
     dtype: torch.dtype = None,
-    prefix: str = None,
-    shared_weights: Dict[str, str] = None,
+    prefix: str = "model",
+    #shared_weights: Dict[str, str] = None,
 ):
     checkpoint_folder = os.path.split(index_filename)[0]
     with open(index_filename, "r") as f:
         index = json.loads(f.read())
     if "weight_map" in index:
         index = index["weight_map"]
-    if prefix:
-        index = {".".join([prefix, k]): v for k, v in index.items()}
 
-    file_to_param_list: Dict[str, List[Tuple]] = {}
+    file_to_params: Dict[str, List[Tuple]] = {}
     for new_name, param in model.named_parameters():
         old_name = model.remap_qualname(new_name)
+        if prefix:
+            old_name = old_name[len(prefix)+1 :]
         if old_name not in index.keys():
+            logging.warning(
+                f"Parameter {new_name} maps to {old_name}, "
+                f"but {old_name} is not found in checkpoint index"
+            )
+            continue
+            """
             if old_name in shared_weights.keys():
                 old_name = shared_weights[old_name]
             else:
-                raise ValueError(
-                    f"Parameter {new_name} maps to {old_name}, "
-                    f"but {old_name} is not found in checkpoint index"
-                )
+            """
         file = index[old_name]
-        param_list = file_to_param_list.setdefault(file, [])
+        param_list = file_to_params.setdefault(file, [])
         param_list.append((new_name, old_name, param))
 
-    file_to_buffer_list: Dict[str, List[Tuple]] = {}
+    file_to_buffers: Dict[str, List[Tuple]] = {}
     for new_name, buffer in model.named_buffers():
         old_name = model.remap_qualname(new_name)
+        if prefix:
+            old_name = old_name[len(prefix)+1 :]
         if old_name not in index.keys():
+            logging.warning(
+                f"Buffer {new_name} maps to {old_name}, "
+                f"but {old_name} is not found in checkpoint index"
+            )
+            continue
+            """
             if old_name in shared_weights.keys():
                 old_name = shared_weights[old_name]
             else:
-                raise ValueError(
-                    f"Buffer {new_name} maps to {old_name}, "
-                    f"but {old_name} is not found in checkpoint index"
-                )
+            """
         file = index[old_name]
-        buffer_list = file_to_buffer_list.setdefault(file, [])
+        buffer_list = file_to_buffers.setdefault(file, [])
         buffer_list.append((new_name, old_name, buffer))
 
-    set1 = set(file_to_param_list.keys())
-    set2 = set(file_to_buffer_list.keys())
+    set1 = set(file_to_params.keys())
+    set2 = set(file_to_buffers.keys())
     used_files = sorted(set1.union(set2))
     logging.info(
         f"Opening checkpoint: {used_files}"
@@ -64,46 +72,22 @@ def load_checkpoint(
     for file in used_files:
         file_path = os.path.join(checkpoint_folder, file)
         checkpoint = torch.load(file_path)
-        if file in file_to_param_list:
-            param_list = file_to_param_list[file]
-            for new_name, old_name, _ in param_list:
-                assert old_name in checkpoint.keys()
-                loaded_weight = checkpoint[old_name]
-                set_module_tensor_to_device(
-                    model, param_name, device, value=loaded_weight, dtype=dtype
-                )
 
-        for param_name, param in checkpoint.items():
-            # Some weights like word_embeddings.weight and shared.weight will be used in different layers, but these layers
-            # may not in the index file, so we can only clone the shared weight to their corresponding layers.
-            if param_name in [
-                "word_embeddings.weight",
-                "shared.weight",
-                "wte.weight",
-            ]:
-                if hasattr(model, "lm_head"):
-                    model.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                        (param.clone()).to(device).to(dtype)
+        for file_to_weights in [file_to_params, file_to_buffers]:
+            if file in file_to_weights:
+                weights = file_to_weights[file]
+                for new_name, old_name, _ in weights:
+                    if old_name not in checkpoint.keys():
+                        raise ValueError(
+                            f"{old_name} not in {file}"
+                        )
+                    loaded_weight = checkpoint[old_name]
+                    set_module_tensor_to_device(
+                        model, new_name, device, value=loaded_weight, dtype=dtype
                     )
-                if hasattr(model, "encoder_embed_tokens"):
-                    model.encoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                        (param.clone()).to(device).to(dtype)
-                    )
-                if hasattr(model, "decoder_embed_tokens"):
-                    model.decoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                        (param.clone()).to(device).to(dtype)
-                    )
-            elif param_name in [
-                "decoder.embed_tokens.weight",
-            ]:
-                # For OPT, the lm_head weight is automatically tied to the embed tokens weight
-                if hasattr(model, "lm_head"):
-                    model.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                        (param.clone()).to(device).to(dtype)
-                    )
-            set_module_tensor_to_device(
-                model, param_name, device, value=param, dtype=dtype
-            )
+
+        handle_shared_weights(model, checkpoint, device=device, dtype=dtype)
+
         del checkpoint
         gc.collect()
 
@@ -112,7 +96,7 @@ def load_checkpoint(
 
 def set_module_tensor_to_device(
     module: nn.Module,
-    param_name: str,
+    qualname: str,
     device: Optional[torch.device] = None,
     value: Optional[torch.Tensor] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
@@ -123,7 +107,7 @@ def set_module_tensor_to_device(
     Args:
         module (`torch.nn.Module`):
             The module in which the tensor we want to move lives.
-        param_name (`str`):
+        qualname (`str`):
             The full name of the parameter/buffer.
         device (`torch.device`):
             The device on which to set the tensor.
@@ -136,86 +120,83 @@ def set_module_tensor_to_device(
     # Recurse if needed
     if value is None:
         return
-    # Parameters are renamed by tracing
-    model_pipe_module_name = "_".join(param_name.split(".")[:-1])
-    model_pipe_tensor_name = param_name.split(".")[-1]
-    # Parameters in module
-    normal_params = [
-        model_pipe_module_name,
-        "model_" + model_pipe_module_name,
-        "transformer_" + model_pipe_module_name,
-    ]
-    # Parameters in module._parameters
-    moved_params = [
-        "moved_" + model_pipe_module_name,
-        "moved_model_" + model_pipe_module_name,
-        "moved_transformer_" + model_pipe_module_name,
-    ]
-    tensor_name = None
-    for param in normal_params:
-        if hasattr(module, param):
-            module = getattr(module, param)
-            tensor_name = model_pipe_tensor_name
-            break
-    if tensor_name is None:
-        for param in moved_params:
-            param = param + "_" + model_pipe_tensor_name
-            if param in module._parameters.keys():
-                tensor_name = param
-                break
-    if tensor_name is None:
-        return
 
     if (
-        tensor_name not in module._parameters
-        and tensor_name not in module._buffers
+        qualname not in module._parameters
+        and qualname not in module._buffers
     ):
         raise ValueError(
-            f"{module} does not have a parameter or a buffer named {tensor_name}."
+            f"{module._get_name()} does not have a parameter or a buffer named {qualname}. "
+            f"Has instead: {module._parameters.keys()} and {module._buffers.keys()}"
         )
-    is_buffer = tensor_name in module._buffers
-    old_value = getattr(module, tensor_name)
 
-    if (
-        old_value.device == torch.device("meta")
-        and device not in [None, torch.device("meta")]
-        and value is None
+    is_buffer = qualname in module._buffers
+    old_value = getattr(module, qualname)
+
+    if dtype is None:
+        # For compatibility with PyTorch load_state_dict which converts state
+        # dict dtype to existing dtype in model
+        dtype = old_value.dtype
+    elif str(value.dtype).startswith(
+        ("torch.uint", "torch.int", "torch.bool")
     ):
-        raise ValueError(
-            f"{tensor_name} is on the meta device, we need a `value` to put in on {device}."
-        )
-
-    if value is not None:
-        if dtype is None:
-            # For compatibility with PyTorch load_state_dict which converts state dict dtype to existing dtype in model
-            value = value.to(old_value.dtype)
-        elif not str(value.dtype).startswith(
-            ("torch.uint", "torch.int", "torch.bool")
-        ):
-            value = value.to(dtype)
+        # Avoid casting these data types
+        dtype = value.dtype
 
     with torch.no_grad():
-        if value is None:
-            new_value = old_value.to(device)
-        elif isinstance(value, torch.Tensor):
-            new_value = value.to(device)
+        if isinstance(value, torch.Tensor):
+            new_value = value.to(device=device, dtype=dtype)
         else:
-            new_value = torch.tensor(value, device=device)
+            new_value = torch.tensor(value, device=device, dtype=dtype)
 
         if is_buffer:
-            module._buffers[tensor_name] = new_value
-        elif value is not None or device not in [
-            None,
-            module._parameters[tensor_name].device,
-        ]:
-            param_cls = type(module._parameters[tensor_name])
-            kwargs = module._parameters[tensor_name].__dict__
+            module._buffers[qualname] = new_value
+        else:
+            param_cls = type(module._parameters[qualname])
+            kwargs = module._parameters[qualname].__dict__
             if param_cls.__name__ == "Int8Params":
-                new_value = param_cls(  # type: ignore[misc]
+                new_param = param_cls(  # type: ignore[misc]
                     new_value, requires_grad=old_value.requires_grad, **kwargs
-                ).to(device)
+                )
             else:
-                new_value = param_cls(  # type: ignore[misc]
+                new_param = param_cls(  # type: ignore[misc]
                     new_value, requires_grad=old_value.requires_grad
-                ).to(device)
-            module._parameters[tensor_name] = new_value.to(dtype)  # type: ignore[assignment]
+                )
+            module._parameters[qualname] = new_param
+
+
+# Some weights like word_embeddings.weight and shared.weight will be used in
+# different layers, but these layers may not in the index file, so we can only
+# clone the shared weight to their corresponding layers.
+def handle_shared_weights(
+    module: nn.Module,
+    checkpoint,
+    device: torch.device = None,
+    dtype: torch.dtype = None,
+):
+    for param_name, param in checkpoint.items():
+        if param_name in [
+            "word_embeddings.weight",
+            "shared.weight",
+            "wte.weight",
+        ]:
+            if hasattr(module, "lm_head"):
+                module.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
+                    (param.clone()).to(device).to(dtype)
+                )
+            if hasattr(module, "encoder_embed_tokens"):
+                module.encoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
+                    (param.clone()).to(device).to(dtype)
+                )
+            if hasattr(module, "decoder_embed_tokens"):
+                module.decoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
+                    (param.clone()).to(device).to(dtype)
+                )
+        elif param_name in [
+            "decoder.embed_tokens.weight",
+        ]:
+            # For OPT, the lm_head weight is automatically tied to the embed tokens weight
+            if hasattr(module, "lm_head"):
+                module.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
+                    (param.clone()).to(device).to(dtype)
+                )

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -29,7 +29,7 @@ def load_checkpoint(
 
     prefix_to_test = [checkpoint_prefix] if checkpoint_prefix else TYPICAL_PREFIXES
 
-    file_to_weights = get_file_to_weight_map(model, index, prefix_to_test)
+    file_to_weights = _get_file_to_weight_map(model, index, prefix_to_test)
 
     used_files = file_to_weights.keys()
     import time
@@ -43,14 +43,12 @@ def load_checkpoint(
 
         if file in file_to_weights:
             weights = file_to_weights[file]
-            for new_name, old_name in weights:
+            for new_name, old_name, clone in weights:
                 assert old_name in checkpoint.keys(), f"{old_name} not in {file}"
                 loaded_weight = checkpoint[old_name]
-                set_module_tensor_to_device(
-                    model, new_name, device, value=loaded_weight, dtype=dtype
+                _set_module_tensor_to_device(
+                    model, new_name, device, value=loaded_weight, dtype=dtype, clone=clone,
                 )
-
-        handle_shared_weights(model, checkpoint, device=device, dtype=dtype)
 
         del checkpoint
         gc.collect()
@@ -58,7 +56,7 @@ def load_checkpoint(
     return model
 
 
-def get_file_to_weight_map(
+def _get_file_to_weight_map(
     model: nn.Module,
     index,
     prefix_to_test: List[str],
@@ -71,8 +69,9 @@ def get_file_to_weight_map(
     ]:
         for new_name, _ in iterator:
             old_name = model.remap_qualname(new_name)
-            cp_weight_name = match_checkpoint_name(old_name, index, prefix_to_test)
+            cp_weight_name, clone_needed = _match_checkpoint_name(old_name, index, prefix_to_test)
             if cp_weight_name is None:
+                # Not found
                 logging.warning(
                     f"Weight {new_name} maps to {old_name}, "
                     f"but {old_name} is not found in checkpoint index"
@@ -80,34 +79,73 @@ def get_file_to_weight_map(
                 continue
             file = index[cp_weight_name]
             weights = file_to_weights.setdefault(file, [])
-            weights.append((new_name, cp_weight_name))
+            weights.append((new_name, cp_weight_name, clone_needed))
 
     return file_to_weights
 
 
-def match_checkpoint_name(
+# Some weights like word_embeddings.weight and shared.weight will be used in
+# different layers, but these layers may not in the index file, so we can only
+# clone the shared weight to their corresponding layers.
+
+TYPICAL_SHARER_WEIGHTS = [
+    "lm_head.weight",  # facebook/opt-6.7b
+    "encoder_embed_tokens.weight",
+]
+
+TYPICAL_SHAREE_WEIGHTS = [
+    "decoder.embed_tokens.weight",
+    "word_embeddings.weight",
+    "shared.weight",
+    "wte.weight",
+]
+
+
+def _match_checkpoint_name(
     old_name: str,
     index,
     prefix_to_test: List[str],
-):
+) -> Tuple[str, bool]:
+    """
+    A helper function to match weight name against those in checkpoint index.
+    Args:
+        old_name (`str`):
+            weight name in original model (retrieved via `remap_qualname()`)
+        index (`Dict`?):
+            checkpoint index
+        prefix_to_test (`List[str]`):
+            prefix to try if direct match is not found
+    Return:
+        weight name in the checkpoint index and whether clone is needed
+    Search rule:
+        - Exact match, no need to clone
+        - Match after prefix, no need to clone
+        - Match via shared weight table, clone needed
+    """
     if old_name in index.keys():
-        return old_name
+        return old_name, False
 
     for prefix in prefix_to_test:
         if (old_name.startswith(prefix)
             and old_name[len(prefix)+1 :] in index.keys()
         ):
-            return old_name[len(prefix)+1 :]
+            return old_name[len(prefix)+1 :], False
 
-    return None
+    if old_name in TYPICAL_SHARER_WEIGHTS:
+        for sharee in TYPICAL_SHAREE_WEIGHTS:
+            if sharee in index.keys():
+                return sharee, True
+
+    return None, False
 
 
-def set_module_tensor_to_device(
+def _set_module_tensor_to_device(
     module: nn.Module,
     qualname: str,
     device: Optional[torch.device] = None,
     value: Optional[torch.Tensor] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
+    clone: bool = False,
 ):
     """
     A helper function to set a given tensor (parameter of buffer) of a module on a specific device (note that doing
@@ -124,6 +162,8 @@ def set_module_tensor_to_device(
         dtype (`torch.dtype`, *optional*):
             If passed along the value of the parameter will be cast to this `dtype`. Otherwise, `value` will be cast to
             the dtype of the existing parameter in the model.
+        clone (`bool`, default is False):
+            whether to copy the input value.
     """
     # Recurse if needed
     if value is None:
@@ -162,7 +202,13 @@ def set_module_tensor_to_device(
     with torch.no_grad():
         if isinstance(value, torch.Tensor):
             new_value = value.to(device=device, dtype=dtype)
+            # In case device and dtype do not change, `new_value` would point to
+            # the same storage as `value`, and we would need to explicitly clone
+            if clone and new_value.data_ptr() == value.data_ptr():
+                new_value = value.clone()
         else:
+            # Note: `torch.tensor()` allocates new memory to copy the data of
+            # tensor, so clone is taken care of
             new_value = torch.tensor(value, device=device, dtype=dtype)
 
         if is_buffer:
@@ -179,40 +225,3 @@ def set_module_tensor_to_device(
                     new_value, requires_grad=old_value.requires_grad
                 )
             submod._parameters[weight] = new_param
-
-
-# Some weights like word_embeddings.weight and shared.weight will be used in
-# different layers, but these layers may not in the index file, so we can only
-# clone the shared weight to their corresponding layers.
-def handle_shared_weights(
-    module: nn.Module,
-    checkpoint,
-    device: torch.device = None,
-    dtype: torch.dtype = None,
-):
-    for param_name, param in checkpoint.items():
-        if param_name in [
-            "word_embeddings.weight",
-            "shared.weight",
-            "wte.weight",
-        ]:
-            if hasattr(module, "lm_head"):
-                module.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                    (param.clone()).to(device).to(dtype)
-                )
-            if hasattr(module, "encoder_embed_tokens"):
-                module.encoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                    (param.clone()).to(device).to(dtype)
-                )
-            if hasattr(module, "decoder_embed_tokens"):
-                module.decoder_embed_tokens.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                    (param.clone()).to(device).to(dtype)
-                )
-        elif param_name in [
-            "decoder.embed_tokens.weight",
-        ]:
-            # For OPT, the lm_head weight is automatically tied to the embed tokens weight
-            if hasattr(module, "lm_head"):
-                module.lm_head.weight = torch.nn.Parameter(  # type: ignore[union-attr]
-                    (param.clone()).to(device).to(dtype)
-                )

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -76,7 +76,7 @@ def _get_file_to_weight_map(
         model.named_buffers(),
     ]:
         for new_name, _ in iterator:
-            old_name = model.remap_qualname(new_name)
+            old_name = model.remap_qualname(new_name)  # type: ignore[operator]
             cp_weight_name, clone_needed = _match_checkpoint_name(
                 old_name, index, prefix_to_test
             )
@@ -113,7 +113,7 @@ def _match_checkpoint_name(
     old_name: str,
     index,
     prefix_to_test: List[str],
-) -> Tuple[str, bool]:
+) -> Tuple[Optional[str], bool]:
     """
     A helper function to match weight name against those in checkpoint index.
     Args:
@@ -153,7 +153,7 @@ def _set_module_tensor_to_device(
     qualname: str,
     device: Optional[torch.device] = None,
     value: Optional[torch.Tensor] = None,
-    dtype: Optional[Union[str, torch.dtype]] = None,
+    dtype: Optional[torch.dtype] = None,
     clone: bool = False,
 ):
     """

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -53,6 +53,7 @@ def _compile(
     checkpoint=False,
     _debug_mask_minibatches: bool = False,
     index_filename=None,
+    checkpoint_prefix: str = None,
     **kwargs,
 ):
     if ranks is None:
@@ -100,6 +101,7 @@ def _compile(
             device,
             index_filename,
             dtype,
+            checkpoint_prefix,
         )
         stage_mod = pipe_model.export(pp_rank)
 


### PR DESCRIPTION
## Description

Today's implementation would load all checkpoint files and check if any of its parameters falls in the current stage.
As a result, we may have O(N^2) file loading.

The PR starts from the stage side and find out which checkpoint files are actually needed to fill its weights. Hopefully this would mean that each stage would only need to open 1-2 files. 

## Tests:

```
torchrun8 hf_generate.py --model_name /fsx/opt-6.7b --index_filename /fsx/opt-6.7b/pytorch_model.bin.index.json --checkpoint_prefix=model
```
The last argument is added because the weights in checkpoint of opt-6.7b do not have "model." prefix in its full qualified name. opt-66b, by contrast, has this prefix.

Similar for Bloom, "transformer." prefix needs to be added to its checkpoint weight names.