### PR TITLE
Deserialize stage init

### DIFF
--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -34,9 +34,7 @@ def load_checkpoint(
     file_to_weights = _get_file_to_weight_map(model, index, prefix_to_test)
 
     used_files = file_to_weights.keys()
-    import time
-
-    logging.info(f"{time.time()} Opening checkpoint: {used_files}")
+    logging.info(f"Opening checkpoint: {used_files}")
 
     for file in used_files:
         file_path = os.path.join(checkpoint_folder, file)

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1478,6 +1478,8 @@ class PipelineDriverBase(torch.nn.Module):
 
         self.stage_to_executor: Dict = {}
 
+        # Ask each RankWorker to create stage thereon
+        # This can involve checkpoint loading in deferred init case
         for stage_id, descr in enumerate(executor_descriptors):
             # Assign stages to rank workers in a round-robin fashion
             rank = self.all_ranks[stage_id % self.world_size]
@@ -1492,7 +1494,10 @@ class PipelineDriverBase(torch.nn.Module):
                     mod_name=descr.name,
                 ),
             )
-            if Pipe.is_stage_init_deferred():
+
+        # Check that each RankWorker has completed stage init
+        if Pipe.is_stage_init_deferred():
+            for stage_id, descr in enumerate(executor_descriptors):
                 logging.debug(
                     f"[root] Waiting stage_id = {stage_id} mod to be confirmed by worker"
                 )
@@ -1500,9 +1505,10 @@ class PipelineDriverBase(torch.nn.Module):
                     1
                 ].confirmed_by_owner():
                     pass
-            self.stage_to_executor[stage_id] = self.remote_stage_executor_rrefs[
-                descr.name
-            ][1]
+
+                self.stage_to_executor[
+                    stage_id
+                ] = self.remote_stage_executor_rrefs[descr.name][1]
 
         # Inform executors of their peers
         for stage_id, executor in self.stage_to_executor.items():


### PR DESCRIPTION
## Description

Previously the `confirmed_by_owner()` call is in the stage init loop. This causes stages to init one after one.

Now we move `confirmed_by_owner()` to a separate loop after the init loop.

Stage init in the checkpoint loading case is now parallelized.