### PR TITLE
Deserialize stage creation

### DIFF
--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -36,7 +36,10 @@ def load_checkpoint(
     used_files = file_to_weights.keys()
     import time
 
-    logging.info(f"{time.time()} Opening checkpoint: {used_files}")
+    logging.info(
+        f"Timestamp {time.time():.2f} "
+        f"Opening checkpoint: {used_files}"
+    )
 
     for file in used_files:
         file_path = os.path.join(checkpoint_folder, file)

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -37,8 +37,7 @@ def load_checkpoint(
     import time
 
     logging.info(
-        f"Timestamp {time.time():.2f} "
-        f"Opening checkpoint: {used_files}"
+        f"Timestamp {time.time():.2f} " f"Opening checkpoint: {used_files}"
     )
 
     for file in used_files:

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1505,9 +1505,9 @@ class PipelineDriverBase(torch.nn.Module):
             ].confirmed_by_owner():
                 pass
 
-            self.stage_to_executor[
-                stage_id
-            ] = self.remote_stage_executor_rrefs[descr.name][1]
+            self.stage_to_executor[stage_id] = self.remote_stage_executor_rrefs[
+                descr.name
+            ][1]
 
         # Inform executors of their peers
         for stage_id, executor in self.stage_to_executor.items():


### PR DESCRIPTION
## Description

Previously the `confirmed_by_owner()` call is in the stage init loop. This serializes stage inits.

Now we move `confirmed_by_owner()` to a separate loop after the init loop.

Stage init in the checkpoint loading case is now parallelized.