### PR TITLE
restore gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+docs/build
+__pycache__
+build
+pippy.egg-info
+pippy/version.py
+dist
+.idea/
+.pyre/
+**/*.json
+**/*.out
+**/.DS_STORE


### PR DESCRIPTION
## Description

the previous merged PR got rid of .gitignore because of its '.watchmanconfig' addition. Here, I restore the .gitignore to its initial state
