### PR TITLE
combine index-file-saving and params-saving into one API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+docs/build
+__pycache__
+build
+pippy.egg-info
+pippy/version.py
+dist
+.idea/
+.pyre/
+**/*.json
+**/*.out
+**/.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-docs/build
 __pycache__
 build
 pippy.egg-info

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -140,7 +140,9 @@ def _save_params(submod: Pipe, checkpoint_dir: str) -> None:
     )
 
 
-def save_checkpoint(stage: Pipe, submod: torch.nn.Module, checkpoint_dir: str) -> None:
+def save_checkpoint(
+    stage: Pipe, submod: Pipe, checkpoint_dir: str
+) -> None:
     """
     Save the entire model's(`stage`) metadata in an index file and the `submod`
     parameters in `checkpoint_dir`

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -133,7 +133,7 @@ def _save_params(submod: torch.nn.Module, checkpoint_dir: str) -> None:
     )
     torch.save(
         {
-            submod.remap_qualname(param_name): param
+            submod.remap_qualname(param_name): param  # type: ignore
             for param_name, param in submod.state_dict().items()
         },
         filepath,
@@ -154,4 +154,4 @@ def save_checkpoint(stage: Pipe, checkpoint_dir: str) -> None:
     if dist.get_rank() == 0:
         _save_index(stage, checkpoint_dir=checkpoint_dir)
 
-    _save_params(stage.submod, checkpoint_dir)
+    _save_params(stage.submod, checkpoint_dir)  # type: ignore

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -118,7 +118,7 @@ def _get_binary_filename(cur_idx: int) -> str:  # type: ignore[valid-type]
     return f"pytorch_model-{idx}-of-{world_size}.bin"
 
 
-def _save_params(submod: Pipe, checkpoint_dir: str) -> None:
+def _save_params(submod: torch.nn.Module, checkpoint_dir: str) -> None:
     """
     writes `module`'s parameters and buffers to disk.
 
@@ -140,9 +140,7 @@ def _save_params(submod: Pipe, checkpoint_dir: str) -> None:
     )
 
 
-def save_checkpoint(
-    stage: Pipe, submod: Pipe, checkpoint_dir: str
-) -> None:
+def save_checkpoint(stage: Pipe, checkpoint_dir: str) -> None:
     """
     Save the entire model's(`stage`) metadata in an index file and the `submod`
     parameters in `checkpoint_dir`
@@ -156,4 +154,4 @@ def save_checkpoint(
     if dist.get_rank() == 0:
         _save_index(stage, checkpoint_dir=checkpoint_dir)
 
-    _save_params(submod, checkpoint_dir)
+    _save_params(stage.submod, checkpoint_dir)

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -118,7 +118,7 @@ def _get_binary_filename(cur_idx: int) -> str:  # type: ignore[valid-type]
     return f"pytorch_model-{idx}-of-{world_size}.bin"
 
 
-def _save_checkpoint(submod: Pipe, checkpoint_dir: str) -> None:
+def _save_params(submod: Pipe, checkpoint_dir: str) -> None:
     """
     writes `module`'s parameters and buffers to disk.
 
@@ -138,3 +138,20 @@ def _save_checkpoint(submod: Pipe, checkpoint_dir: str) -> None:
         },
         filepath,
     )
+
+
+def save_checkpoint(stage: Pipe, submod: torch.nn.Module, checkpoint_dir: str) -> None:
+    """
+    Save the entire model's(`stage`) metadata in an index file and the `submod`
+    parameters in `checkpoint_dir`
+
+    Args:
+        stage(`Pipe`): model pipeline graph
+        submod(`torch.nn.Module`): submod whose params are to be saved
+        checkpoin_dir(`str`): directory where to save the index file and params binaries
+    """
+    # write index file in rank 0
+    if dist.get_rank() == 0:
+        _save_index(stage, checkpoint_dir=checkpoint_dir)
+
+    _save_params(submod, checkpoint_dir)

--- a/test/local_test_ckpt_index_file.py
+++ b/test/local_test_ckpt_index_file.py
@@ -6,10 +6,7 @@ import shutil
 import json
 import os
 
-from pippy.hf._SaveModule import (
-    _save_index,
-    _save_checkpoint,
-)
+from pippy.hf._SaveModule import save_checkpoint
 from pippy.IR import pipe_split, TrivialLossWrapper
 from pippy.LoadModule import load_checkpoint
 from pippy.compile import compile_stage
@@ -94,10 +91,13 @@ def run_worker(args: List[str | int]) -> None:
     else:
         stage()
 
+    # Take an optimization step
+    optimizer.step()
+    ref = deepcopy(stage.submod.state_dict())
+    save_checkpoint(stage, stage.submod, CKPT_DIR)
+
     # save index file in rank 0
     if args.rank == 0:
-        _save_index(stage, checkpoint_dir=CKPT_DIR)
-
         filepath = os.path.join(CKPT_DIR, DEFAULT_FILENAME)
         with open(filepath) as f:
             content = f.read()
@@ -114,11 +114,6 @@ def run_worker(args: List[str | int]) -> None:
         assert len(data["weight_map"]) == 7
         for param in WEIGHT_MAP:
             assert param in data["weight_map"]
-
-    # Take an optimization step
-    optimizer.step()
-    ref = deepcopy(stage.submod.state_dict())
-    _save_checkpoint(stage.submod, CKPT_DIR)
 
     # second run
     # Zero gradients

--- a/test/local_test_ckpt_index_file.py
+++ b/test/local_test_ckpt_index_file.py
@@ -6,19 +6,16 @@ import unittest
 from copy import deepcopy
 from typing import List
 
-from pippy.hf._SaveModule import save_checkpoint
-from pippy.IR import pipe_split, TrivialLossWrapper
-from pippy.LoadModule import load_checkpoint
-from pippy.compile import compile_stage
 import torch
 
 import torch.distributed as dist
 import torch.optim as optim
 from pippy.compile import compile_stage
 
-from pippy.hf._SaveModule import _save_checkpoint, _save_index
+from pippy.hf._SaveModule import save_checkpoint
 from pippy.IR import pipe_split, TrivialLossWrapper
 from pippy.LoadModule import load_checkpoint
+
 
 DEFAULT_FILENAME = "pytorch_model.bin.index.json"
 CKPT_DIR = "test_ckpts"

--- a/test/local_test_ckpt_index_file.py
+++ b/test/local_test_ckpt_index_file.py
@@ -94,7 +94,7 @@ def run_worker(args: List[str | int]) -> None:
     # Take an optimization step
     optimizer.step()
     ref = deepcopy(stage.submod.state_dict())
-    save_checkpoint(stage, stage.submod, CKPT_DIR)
+    save_checkpoint(stage, CKPT_DIR)
 
     # save index file in rank 0
     if args.rank == 0:


### PR DESCRIPTION
## Description

bring together `_save_index` and `_save_params` into one function `save_checkpoint`. The entire module is used to write the index file, only in rank 0, while submodule parameters are saved to a file in each rank. The associated ckpt test is updated to reflect this change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

- [x] Test LocalIndexMetadataTest

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
