### PR TITLE
save optim state dict

### DIFF
--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -158,13 +158,8 @@ def _save_optim_state(
     filepath = os.path.join(
         checkpoint_dir, _get_binary_filename(dist.get_rank(), is_optim=True)
     )
-    torch.save(
-        {
-            param_name: param  # type: ignore
-            for param_name, param in optimizer.state_dict().items()
-        },
-        filepath,
-    )
+    # save optimizer state directly
+    torch.save(optimizer.state_dict(), filepath)
 
 
 def save_checkpoint(


### PR DESCRIPTION
## Description

Save optimizer's state into a diff binary file such that for each rank, there are two state bin files: submod params and optim state.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Will update checkpoint test to reflect change in a different PR.

## Checklist:

- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
