### PR TITLE
test optimizer using torch.load

### DIFF
--- a/test/local_test_checkpoint.py
+++ b/test/local_test_checkpoint.py
@@ -12,7 +12,7 @@ import torch.distributed as dist
 import torch.optim as optim
 from pippy.compile import compile_stage
 
-from pippy.hf._SaveModule import save_checkpoint, _get_binary_filename
+from pippy.hf._SaveModule import _get_binary_filename, save_checkpoint
 from pippy.IR import pipe_split, TrivialLossWrapper
 from pippy.LoadModule import load_checkpoint
 
@@ -141,7 +141,13 @@ def run_worker(args: List[str | int]) -> None:
         args.device,
     )
     # load optim
-    optimizer.load_state_dict(torch.load(os.path.join(CKPT_DIR, _get_binary_filename(dist.get_rank(), is_optim=True))))
+    optimizer.load_state_dict(
+        torch.load(
+            os.path.join(
+                CKPT_DIR, _get_binary_filename(dist.get_rank(), is_optim=True)
+            )
+        )
+    )
 
     torch.testing.assert_close(mod.state_dict(), submod_ref)
     torch.testing.assert_close(optimizer.state_dict(), optim_ref)


### PR DESCRIPTION
## Description

Since we're also saving the optimizer's state dict (in a different binary file for each rank), we can't use load_checkpoint to check that it works. Here, I use torch.load to check that a certain reference optimizer state dict is similar/close to the saved optimizer's state dict, after a `step()` run.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Has code been commented, particularly in hard-to-understand areas?
