### PR TITLE
Disable bert CI

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -106,8 +106,8 @@ jobs:
         run: python test/local_test_null_coalesce_accumulate.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }}
       - name: Run PP + DDP test
         run: python test/local_test_ddp.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }} --checkpoint ${{ matrix.checkpoint }}
-      - name: Run HF BERT forward-only integration test
-        run: python test/local_test_forward_hf_bert.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }} --checkpoint ${{ matrix.checkpoint }}
+      #- name: Run HF BERT forward-only integration test
+      #  run: python test/local_test_forward_hf_bert.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }} --checkpoint ${{ matrix.checkpoint }}
       - name: Run HF GPT2 forward-only integration test
         run: python test/local_test_forward_hf_gpt2.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }} --checkpoint ${{ matrix.checkpoint }}
       - name: Run visualizer test


### PR DESCRIPTION
## Description

Disable BERT test in CI.

Seems to be related to PyTorch nightly change.
First seen Jun 30, 2023:
https://github.com/pytorch/PiPPy/actions/runs/5426074544/jobs/9867645401

```
-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/usr/local/lib/python3.8/site-packages/torchpippy-0.1.1-py3.8.egg/pippy/utils.py", line 268, in run_worker
    run_func(my_pp_ranks, args, *extra_args)
  File "/__w/PiPPy/PiPPy/test/local_test_forward_hf_bert.py", line 74, in run_master
    bert_pipe = Pipe.from_tracing(
  File "/usr/local/lib/python3.8/site-packages/torchpippy-0.1.1-py3.8.egg/pippy/IR.py", line 10[54](https://github.com/pytorch/PiPPy/actions/runs/5509919435/jobs/10043352906?pr=835#step:12:55), in from_tracing
    graph = _pipeline_tracer.trace(mod, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/torchpippy-0.1.1-py3.8.egg/pippy/hf/utils.py", line 266, in trace
    graph = super().trace(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/transformers/utils/fx.py", line 1088, in trace
    self.graph = super().trace(root, concrete_args=concrete_args)
  File "/usr/local/lib/python3.8/site-packages/torch/fx/_symbolic_trace.py", line 778, in trace
    (self.create_arg(fn(*args)),),
  File "/usr/local/lib/python3.8/site-packages/transformers/models/bert/modeling_bert.py", line 970, in forward
    self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
  File "/usr/local/lib/python3.8/site-packages/transformers/modeling_utils.py", line 3488, in warn_if_padding_and_no_attention_mask
    if self.config.pad_token_id in input_ids[:, [-1, 0]]:
  File "/usr/local/lib/python3.8/site-packages/transformers/utils/fx.py", line [64](https://github.com/pytorch/PiPPy/actions/runs/5509919435/jobs/10043352906?pr=835#step:12:65)6, in __contains__
    return key in self._metadata
  File "/usr/local/lib/python3.8/site-packages/torch/_tensor.py", line 997, in __contains__
    return (element == self).any().item()  # type: ignore[union-attr]
NotImplementedError: Could not run 'aten::_local_scalar_dense' with arguments from the 'Meta' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::_local_scalar_dense' is only available for these backends: [CPU, CUDA, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMeta, AutogradMTIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradNestedTensor, Tracer, AutocastCPU, AutocastCUDA, FuncTorchBatched, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PythonDispatcher].
```