### PR TITLE
place optim state_dict loading inside `load_checkpoint`

### DIFF
--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -20,16 +20,17 @@ TYPICAL_PREFIXES = [
 def load_checkpoint(
     model: nn.Module,
     index_filename: Union[str, os.PathLike],
+    optim: torch.optim.Optimizer = None,
     device: torch.device = None,
     dtype: torch.dtype = None,
     checkpoint_prefix: str = None,
-    optim: torch.optim.Optimizer = None,
 ) -> tuple[nn.Module, torch.optim.Optimizer] | nn.Module:
     """
     Load a checkpoint from a model file.
     Args:
         model (`torch.nn.Module`): the model to load the checkpoint into
         index_filename (`Union[str, os.PathLike]`): path to the checkpoint's index (metadata file)
+        optim (`torch.optim.Optimizer`): optimizer object to load ckpt state dict into
         device (`torch.device`): the device on which to load the checkpoint
         dtype (`torch.dtype`): the dtype on which to load the checkpoint
         checkpoint_prefix (`str`): the prefix of the checkpoint to load

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -24,9 +24,9 @@ def load_checkpoint(
     device: torch.device = None,
     dtype: torch.dtype = None,
     checkpoint_prefix: str = None,
-) -> Union[nn.Module, Tuple[nn.Module, torch.optim.Optimizer]]:  # type: ignore
+):
     """
-    Load a checkpoint from a model file.
+    Load a checkpoint from a model (and optimizer) file.
     Args:
         model (`torch.nn.Module`): the model to load the checkpoint into
         index_filename (`Union[str, os.PathLike]`): path to the checkpoint's index (metadata file)
@@ -35,7 +35,8 @@ def load_checkpoint(
         dtype (`torch.dtype`): the dtype on which to load the checkpoint
         checkpoint_prefix (`str`): the prefix of the checkpoint to load
     Returns:
-        The loaded checkpoint model
+        The loaded checkpoint model, or, if an optimizer is passed as an argument,
+        both the loaded checkpoint model and a optimizer
     Example:
         ```
         checkpoint = load_checkpoint(model, index_filename, device, dtype)

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -5,8 +5,8 @@ import os
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-from torch import nn
 import torch.distributed as dist
+from torch import nn
 
 from pippy.utils import _get_binary_filename
 
@@ -24,7 +24,7 @@ def load_checkpoint(
     device: torch.device = None,
     dtype: torch.dtype = None,
     checkpoint_prefix: str = None,
-) -> tuple[nn.Module, torch.optim.Optimizer] | nn.Module:
+):
     """
     Load a checkpoint from a model file.
     Args:
@@ -47,7 +47,8 @@ def load_checkpoint(
         optim.load_state_dict(
             torch.load(
                 os.path.join(
-                    checkpoint_folder, _get_binary_filename(dist.get_rank(), is_optim=True)
+                    checkpoint_folder,
+                    _get_binary_filename(dist.get_rank(), is_optim=True),
                 )
             )
         )

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -43,16 +43,6 @@ def load_checkpoint(
     """
     checkpoint_folder = os.path.split(index_filename)[0]
 
-    if optim:
-        optim.load_state_dict(
-            torch.load(
-                os.path.join(
-                    checkpoint_folder,
-                    _get_binary_filename(dist.get_rank(), is_optim=True),
-                )
-            )
-        )
-
     with open(index_filename, "r") as f:
         index = json.loads(f.read())
     if "weight_map" in index:
@@ -93,6 +83,16 @@ def load_checkpoint(
 
         del checkpoint
         gc.collect()
+
+    if optim:
+        optim.load_state_dict(
+            torch.load(
+                os.path.join(
+                    checkpoint_folder,
+                    _get_binary_filename(dist.get_rank(), is_optim=True),
+                )
+            )
+        )
 
     if optim:
         return model, optim

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -24,7 +24,7 @@ def load_checkpoint(
     device: torch.device = None,
     dtype: torch.dtype = None,
     checkpoint_prefix: str = None,
-):
+) -> Union[nn.Module, Tuple[nn.Module, torch.optim.Optimizer]]:
     """
     Load a checkpoint from a model file.
     Args:

--- a/pippy/LoadModule.py
+++ b/pippy/LoadModule.py
@@ -24,7 +24,7 @@ def load_checkpoint(
     device: torch.device = None,
     dtype: torch.dtype = None,
     checkpoint_prefix: str = None,
-) -> Union[nn.Module, Tuple[nn.Module, torch.optim.Optimizer]]:
+) -> Union[nn.Module, Tuple[nn.Module, torch.optim.Optimizer]]:  # type: ignore
     """
     Load a checkpoint from a model file.
     Args:

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 
 from pippy.IR import Pipe
+from pippy.utils import _get_binary_filename
 
 CKPT_INDEX_JSON_FILENAME = "pytorch_model.bin.index.json"
 
@@ -108,26 +109,6 @@ def _save_index(
     _atomic_write(json_str, filepath)
 
     logging.info(f"Saved index file to {filepath}")
-
-
-def _get_binary_filename(cur_idx: int, is_optim: bool = False) -> str:  # type: ignore[valid-type]
-    """
-    Gets filename for pytorch checkpoint binary based on current index and world size.
-
-    Args:
-        cur_idx (int): current device index
-        is_optim (bool): True if generating binary filename for optimizer,
-                         False otherwise
-
-    Returns:
-        str: checkpoint filename
-    """
-    idx = str(cur_idx + 1).zfill(5)
-    world_size = str(dist.get_world_size()).zfill(5)
-
-    state_type = "optim" if is_optim else "model"
-
-    return f"pytorch_{state_type}-{idx}-of-{world_size}.bin"
 
 
 def _save_params(submod: torch.nn.Module, checkpoint_dir: str) -> None:

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -4,6 +4,8 @@ import os
 import socket
 from typing import List
 
+import torch.distributed as dist
+
 
 # Pinning process to a separate GPU if not yet done by launch script
 # Notes:
@@ -309,3 +311,23 @@ def flatten_args(args):
     pippy.fx.node.map_aggregate(args, extract_tensor_args, dont_traverse_size)
 
     return flat_args
+
+
+def _get_binary_filename(cur_idx: int, is_optim: bool = False) -> str:  # type: ignore[valid-type]
+    """
+    Gets filename for pytorch checkpoint binary based on current index and world size.
+
+    Args:
+        cur_idx (int): current device index
+        is_optim (bool): True if generating binary filename for optimizer,
+                         False otherwise
+
+    Returns:
+        str: checkpoint filename
+    """
+    idx = str(cur_idx + 1).zfill(5)
+    world_size = str(dist.get_world_size()).zfill(5)
+
+    state_type = "optim" if is_optim else "model"
+
+    return f"pytorch_{state_type}-{idx}-of-{world_size}.bin"

--- a/test/local_test_checkpoint.py
+++ b/test/local_test_checkpoint.py
@@ -12,7 +12,8 @@ import torch.distributed as dist
 import torch.optim as optim
 from pippy.compile import compile_stage
 
-from pippy.hf._SaveModule import _get_binary_filename, save_checkpoint
+from pippy.hf._SaveModule import save_checkpoint
+from pippy.utils import _get_binary_filename
 from pippy.IR import pipe_split, TrivialLossWrapper
 from pippy.LoadModule import load_checkpoint
 
@@ -134,19 +135,12 @@ def run_worker(args: List[str | int]) -> None:
     # Take an optimization step
     optimizer.step()
 
-    # load ckpt
-    mod = load_checkpoint(
+    # new api
+    mod, optimizer = load_checkpoint(
         stage.submod,
         os.path.join(CKPT_DIR, "pytorch_model.bin.index.json"),
         args.device,
-    )
-    # load optim
-    optimizer.load_state_dict(
-        torch.load(
-            os.path.join(
-                CKPT_DIR, _get_binary_filename(dist.get_rank(), is_optim=True)
-            )
-        )
+        optim=optimizer,
     )
 
     torch.testing.assert_close(mod.state_dict(), submod_ref)

--- a/test/local_test_checkpoint.py
+++ b/test/local_test_checkpoint.py
@@ -13,7 +13,6 @@ import torch.optim as optim
 from pippy.compile import compile_stage
 
 from pippy.hf._SaveModule import save_checkpoint
-from pippy.utils import _get_binary_filename
 from pippy.IR import pipe_split, TrivialLossWrapper
 from pippy.LoadModule import load_checkpoint
 


### PR DESCRIPTION
## Description

To bring all the checkpoint loading operations into one single API, I place the optim load_state_dict code inside load_checkpoint.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
