### PR TITLE
Create ckpt dir only once in _SaveModule

### DIFF
--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -102,11 +102,6 @@ def _save_index(
 
     filepath = os.path.join(checkpoint_dir, ckpt_index_filename)
 
-    # create checkpoint directory if it doesn't exist
-    if not os.path.exists(checkpoint_dir):
-        pathlib.Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
-        # os.mkdir(checkpoint_dir)
-
     # write index file atomically to avoid partial/corrupted writes
     _atomic_write(json_str, filepath)
 
@@ -121,9 +116,6 @@ def _save_params(submod: torch.nn.Module, checkpoint_dir: str) -> None:
         submod(`Pipe`): a submodule of the model's graph
         checkpoint_dir(`str`): where to keep the checkpoint binaries
     """
-    if not os.path.exists(checkpoint_dir):
-        pathlib.Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
-        # os.mkdir(checkpoint_dir)
     filepath = os.path.join(
         checkpoint_dir, _get_binary_filename(dist.get_rank())
     )
@@ -146,9 +138,6 @@ def _save_optim_state(
         optimizer(`torch.optim.Optimizer`): pytorch optimizer
         checkpoint_dir(`str`): where to keep the checkpoint binaries
     """
-    if not os.path.exists(checkpoint_dir):
-        pathlib.Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
-        # os.mkdir(checkpoint_dir)
     filepath = os.path.join(
         checkpoint_dir, _get_binary_filename(dist.get_rank(), is_optim=True)
     )
@@ -171,6 +160,10 @@ def save_checkpoint(
                               defaults to `checkpoints`
         optimizer(`torch.optim.Optimizer`): optimizer whose state dict is to be saved
     """
+    # create checkpoint directory if it doesn't exist
+    if not os.path.exists(checkpoint_dir):
+        pathlib.Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
+        
     # write index file in rank 0
     if dist.get_rank() == 0:
         _save_index(stage, checkpoint_dir=checkpoint_dir)

--- a/pippy/hf/_SaveModule.py
+++ b/pippy/hf/_SaveModule.py
@@ -163,7 +163,7 @@ def save_checkpoint(
     # create checkpoint directory if it doesn't exist
     if not os.path.exists(checkpoint_dir):
         pathlib.Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
-        
+
     # write index file in rank 0
     if dist.get_rank() == 0:
         _save_index(stage, checkpoint_dir=checkpoint_dir)

--- a/test/local_test_checkpoint.py
+++ b/test/local_test_checkpoint.py
@@ -98,6 +98,7 @@ def run_worker(args: List[str | int]) -> None:
     optimizer.step()
     ref_state_dict = deepcopy(stage.submod.state_dict())
     ref_optim_state_dict = deepcopy(optimizer.state_dict())
+
     save_checkpoint(stage, CKPT_DIR, optimizer)
 
     # save index file in rank 0
@@ -135,15 +136,17 @@ def run_worker(args: List[str | int]) -> None:
     optimizer.step()
 
     # new api
-    mod, optimizer = load_checkpoint(
-        stage.submod,
-        os.path.join(CKPT_DIR, "pytorch_model.bin.index.json"),
-        args.device,
-        optim=optimizer,
-    )
+    # after index file has been written, load_checkpoint will read it
+    if os.path.exists(os.path.join(CKPT_DIR, DEFAULT_FILENAME)):
+        mod, optimizer = load_checkpoint(
+            stage.submod,
+            os.path.join(CKPT_DIR, DEFAULT_FILENAME),
+            optim=optimizer,
+            device=args.device,
+        )
 
-    torch.testing.assert_close(mod.state_dict(), submod_ref)
-    torch.testing.assert_close(optimizer.state_dict(), optim_ref)
+        torch.testing.assert_close(mod.state_dict(), ref_state_dict)
+        torch.testing.assert_close(optimizer.state_dict(), ref_optim_state_dict)
 
     dist.barrier()
     print(f"Rank {args.rank} completes")


### PR DESCRIPTION
## Description

I was initially checking whether the ckpt dir existed, and writing it, when writing the mod state_dict, index file, and optim state dicts. Here, I do that only once.

## Feature/Issue validation/testing

The test/local_test_checkpoint.py test ensures things are running smoothly.

## Checklist:

- [x] Has code been commented, particularly in hard-to-understand areas?
