### PR TITLE
Modularize microbatch fwd bwd

### DIFF
--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -609,7 +609,7 @@ class PipelineStage(torch.nn.Module):
         grad_send_reqs = self._send_grads(grads_input)
         self.all_grad_send_reqs += grad_send_reqs
 
-    def forward(self, *args, **kwargs):
+    def clear_runtime_states(self):
         # map microbatch ID to list of forward tensor args
         self.fwd_cache.clear()
         # Activation send requests of all chunk
@@ -618,6 +618,10 @@ class PipelineStage(torch.nn.Module):
         self.all_grad_send_reqs.clear()
         # Caching chunk outputs for final output merge or reduction
         self.output_chunks.clear()
+
+    def forward(self, *args, **kwargs):
+        # Clean per iteration
+        self.clear_runtime_states()
 
         # Split inputs into chunks
         self.split_inputs(args, kwargs)
@@ -677,14 +681,8 @@ class PipelineStage1F1B(PipelineStage):
         )
 
     def forward(self, *args, **kwargs):
-        # map microbatch ID to list of forward tensor args
-        self.fwd_cache.clear()
-        # Activation send requests of all chunk
-        self.all_act_send_reqs.clear()
-        # Grad send requests of all chunk
-        self.all_grad_send_reqs.clear()
-        # Caching chunk outputs for final output merge or reduction
-        self.output_chunks.clear()
+        # Clean per iteration
+        self.clear_runtime_states()
 
         # Split inputs into chunks
         self.split_inputs(args, kwargs)

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -127,6 +127,12 @@ class PipelineStage(torch.nn.Module):
         # Prepare send/recv infrastructure
         self._prepare_send_recv_infra()
 
+    def is_first(self):
+        return self.rank == 0
+
+    def is_last(self):
+        return self.rank == self.nstages - 1
+
     def _prepare_send_recv_infra(self):
         """
         Create send/recv infrastructures for activations (during forward) and
@@ -646,7 +652,7 @@ class PipelineStage(torch.nn.Module):
             work.wait()
 
         # Last rank return merged results per original format
-        if self.rank == self.nstages - 1:
+        if self.is_last():
             return merge_chunks(
                 self.output_chunks,
                 self.output_chunk_spec,
@@ -715,7 +721,7 @@ class PipelineStage1F1B(PipelineStage):
             work.wait()
 
         # Last rank return merged results per original format
-        if self.rank == self.nstages - 1:
+        if self.is_last():
             return merge_chunks(
                 self.output_chunks,
                 self.output_chunk_spec,

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -339,7 +339,8 @@ class PipelineStage(torch.nn.Module):
             )
 
         logging.info(
-            f"[{self.group_rank}][{self.name}] " f"Grad recv info: {grad_recv_info}"
+            f"[{self.group_rank}][{self.name}] "
+            f"Grad recv info: {grad_recv_info}"
         )
         return grad_recv_info
 
@@ -363,7 +364,8 @@ class PipelineStage(torch.nn.Module):
         pippy.fx.node.map_aggregate(kwargs_recv_info, map_recv_to_send)
 
         logging.info(
-            f"[{self.group_rank}][{self.name}] " f"Grad send info: {grad_send_info}"
+            f"[{self.group_rank}][{self.name}] "
+            f"Grad send info: {grad_send_info}"
         )
         return grad_send_info
 
@@ -518,9 +520,7 @@ class PipelineStage(torch.nn.Module):
                     grad,
                     peer_rank
                     if self.group is None
-                    else dist.get_global_rank(
-                        self.group, peer_rank
-                    ),  # TODO
+                    else dist.get_global_rank(self.group, peer_rank),  # TODO
                     group=self.group,
                 )
                 grad_send_reqs.append(work)

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -625,6 +625,12 @@ class PipelineStage(torch.nn.Module):
         # Caching chunk outputs for final output merge or reduction
         self.output_chunks.clear()
 
+    def merge_output_chunks(self):
+        return merge_chunks(
+            self.output_chunks,
+            self.output_chunk_spec,
+        )
+
     def forward(self, *args, **kwargs):
         # Clean per iteration
         self.clear_runtime_states()
@@ -653,10 +659,7 @@ class PipelineStage(torch.nn.Module):
 
         # Last rank return merged results per original format
         if self.is_last():
-            return merge_chunks(
-                self.output_chunks,
-                self.output_chunk_spec,
-            )
+            return self.merge_output_chunks()
         else:
             return None
 
@@ -722,9 +725,6 @@ class PipelineStage1F1B(PipelineStage):
 
         # Last rank return merged results per original format
         if self.is_last():
-            return merge_chunks(
-                self.output_chunks,
-                self.output_chunk_spec,
-            )
+            return self.merge_output_chunks()
         else:
             return None

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -84,7 +84,7 @@ class PipelineStage(torch.nn.Module):
         # Grad send requests of all chunk
         self.all_grad_send_reqs: List[dist.Work] = []
         # Caching chunk outputs for final output merge or reduction
-        self.output_chunks = []
+        self.output_chunks: List[Any] = []
 
         # Find my submodule
         self.split_gm = self.pipe.split_gm
@@ -422,7 +422,7 @@ class PipelineStage(torch.nn.Module):
             if isinstance(info, RecvInfo):
                 return act_recv(info)
             else:
-                return chunk_args_list.pop(0)
+                return chunk_args_list.pop(0)  # type: ignore[has-type]
 
         composite_args = pippy.fx.node.map_aggregate(
             self.args_recv_info[chunk],
@@ -436,8 +436,8 @@ class PipelineStage(torch.nn.Module):
             if isinstance(info, RecvInfo):
                 return act_recv(info)
             else:
-                k = next(iter(chunk_kwargs))
-                return chunk_kwargs.pop(k)
+                k = next(iter(chunk_kwargs))  # type: ignore[has-type]
+                return chunk_kwargs.pop(k)  # type: ignore[has-type]
 
         composite_kwargs = pippy.fx.node.map_aggregate(
             self.kwargs_recv_info[chunk],

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -218,8 +218,8 @@ def all_compile(
 
 def compile_stage(
     mod: torch.nn.Module,
-    rank: int,
-    num_ranks: int,
+    stage_index: int,
+    num_stages: int,
     num_chunks: int,
     device: torch.device,
     group: dist.ProcessGroup,
@@ -257,7 +257,7 @@ def compile_stage(
     )
 
     gm = pipe.split_gm
-    if rank == 0:
+    if stage_index == 0:
         logging.info(gm)
         if PIPPY_VERBOSITY == "INFO":
             gm.graph.print_tabular()
@@ -298,24 +298,24 @@ def compile_stage(
     if schedule == "1F1B":
         return PipelineStage1F1B(
             pipe,
-            rank,
-            num_ranks,
+            stage_index,
+            num_stages,
             num_chunks,
             device,
-            group,
-            args_chunk_spec,
-            kwargs_chunk_spec,
-            output_chunk_spec,
+            group=group,
+            args_chunk_spec=args_chunk_spec,
+            kwargs_chunk_spec=kwargs_chunk_spec,
+            output_chunk_spec=output_chunk_spec,
         )
     else:
         return PipelineStage(
             pipe,
-            rank,
-            num_ranks,
+            stage_index,
+            num_stages,
             num_chunks,
             device,
-            group,
-            args_chunk_spec,
-            kwargs_chunk_spec,
-            output_chunk_spec,
+            group=group,
+            args_chunk_spec=args_chunk_spec,
+            kwargs_chunk_spec=kwargs_chunk_spec,
+            output_chunk_spec=output_chunk_spec,
         )

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ page](https://github.com/pytorch/PiPPy).
 
 class clean(distutils.command.clean.clean):  # type: ignore
     def run(self):
-
         with open(".gitignore", "r") as f:
             ignores = f.read()
             for wildcard in filter(None, ignores.split("\n")):


### PR DESCRIPTION
## Description

1. Modularize code into `forward_one_chunk` and `backward_one_chunk`, for the purpose of easy schedule implementation.

2. Rename `rank` in `PipelineStage` to `stage_index`, as stage is a virtual concept. For example, in Interleaved 1F1B, one rank can hold multiple stages.