### PR TITLE
Expose _debug_mask_minibatches for stable numerical testing

### DIFF
--- a/test/local_test_c10d.py
+++ b/test/local_test_c10d.py
@@ -6,8 +6,13 @@ import unittest
 import torch
 import torch.distributed as dist
 
+import pippy
 from pippy.compile import compile_stage
 from pippy.IR import pipe_split
+
+
+# For stable numerical testing
+pippy.microbatch._debug_mask_minibatches = True
 
 
 d_hid = 512


### PR DESCRIPTION
## Description

`_debug_mask_minibatches` specifies to send masked versions of the mini-batch
through instead of micro-batch slices--this can be used for more stable
numerical testing (see [A Note About Correctness Testing])

For numerical tests, we can set it to True at the top of the test files:
```
pippy.microbatch._debug_mask_minibatches = True
```

Fixes #871 