### PR TITLE
Add torch profiling based on context manager for pipeline scheduler

### DIFF
--- a/test/multinode_trainer.slurm
+++ b/test/multinode_trainer.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH --job-name=looped-bfs-trainer
+#SBATCH --job-name=test_pipeline_schedules
 
 #SBATCH --ntasks=2
 
@@ -47,5 +47,5 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 dcgmi profile --pause
 # adjust sbatch --ntasks and sbatch --nodes above and --nnodes below
 # to your specific node count, and update target launch file.
-srun torchrun --nnodes 2 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./multinode_bfs.py
+srun torchrun --nnodes 2 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./test_pipeline_schedule.py --schedules gpipe looped_bfs
 dcgmi profile --resume

--- a/test/run_pipeline_scheduler.sh
+++ b/test/run_pipeline_scheduler.sh
@@ -1,8 +1,3 @@
 # To run samples:
-# bash run_example.sh {num_gpus}{file_to_run.py} 
-# file_to_run = example to launch.  Default = 'test_pipeline_schedule.py'
-# num_gpus = num local gpus to use (must be at least 2). Default = 8
-# schedule = --schedules
-#echo "Launching ${2:-test_pipeline_schedule.py} with ${1:-8} gpus"
-torchrun --nnodes=1 --nproc_per_node 8 --rdzv_endpoint="localhost:59123" test_pipeline_schedule.py --profiler True
-#torchrun --nnodes=1 --nproc_per_node=${1:-8} --rdzv_id=101 --rdzv_endpoint="localhost:5972" ${2:-test_pipeline_schedule.py}
+# launcher for testing pipeline schedules
+torchrun --nnodes=1 --nproc_per_node 8 --rdzv_endpoint="localhost:59124" test_pipeline_schedule.py

--- a/test/run_pipeline_scheduler.sh
+++ b/test/run_pipeline_scheduler.sh
@@ -1,0 +1,8 @@
+# To run samples:
+# bash run_example.sh {num_gpus}{file_to_run.py} 
+# file_to_run = example to launch.  Default = 'test_pipeline_schedule.py'
+# num_gpus = num local gpus to use (must be at least 2). Default = 8
+# schedule = --schedules
+#echo "Launching ${2:-test_pipeline_schedule.py} with ${1:-8} gpus"
+torchrun --nnodes=1 --nproc_per_node 8 --rdzv_endpoint="localhost:59123" test_pipeline_schedule.py --profiler True
+#torchrun --nnodes=1 --nproc_per_node=${1:-8} --rdzv_id=101 --rdzv_endpoint="localhost:5972" ${2:-test_pipeline_schedule.py}

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -24,7 +24,7 @@ import os
 from contextlib import contextmanager, nullcontext
 
 from datetime import timedelta
-from torch.profiler import record_function, profile, ProfilerActivity
+from torch.profiler import record_function
 
 import torch
 import torch.distributed as dist

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -125,9 +125,9 @@ def main(**kwargs):
     
     rank_print(f"My KWARGS are {kwargs}")
 
-    input_dim = 400#0
-    hidden_dim = 800#0
-    output_dim = 400#0
+    input_dim = 4000
+    hidden_dim = 8000
+    output_dim = 4000
 
     module_list = torch.nn.ModuleList(
         modules=[

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         choices=["gpipe", "looped_bfs", "looped_dfs"],
-        default=["gpipe",], #  "looped_bfs", "looped_dfs"],
+        default=["gpipe","looped_bfs", "looped_dfs"],
     )
     parser.add_argument("--device", type=str, default="cuda")
     args = parser.parse_args()


### PR DESCRIPTION
## Description
This PR adds a context based profiling manager (maybe_run_profiler) to the pipeline scheduler training loop. 
The idea of using a context manager is to ensure no profiler overhead if not profiling, while at the same time not requiring two different training loops (where one has a profiler, the other does not, resulting in duplicate code). 

Profiling is controlled via the --profiler True flag on launch.  
Traces are saved to the --trace_dir which now defaults to ./pipeline_traces
Updates to how the profiler is run, can be done in the context manager code block (i.e. adding warmup, etc). 

<img width="313" alt="profiler_custom_handler" src="https://github.com/pytorch/PiPPy/assets/46302957/00e1dfe3-ec16-4577-adcd-65ce0a15da1f">


Side update is the multinode.slurm file is updated to launch the new name, test_pipeline_schedules.py. 
Fixes #(issue)

## Type of change

Please delete options that are not relevant.
- [ X] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing
Tested with and without running profiler on single node.  
Tested without profiler on multinode. 