### PR TITLE
Upgrade pipeline scheduler test to use device_mesh

### DIFF
--- a/test/multinode_trainer.slurm
+++ b/test/multinode_trainer.slurm
@@ -2,9 +2,9 @@
 
 #SBATCH --job-name=test_pipeline_schedules
 
-#SBATCH --ntasks=1
+#SBATCH --ntasks=2
 
-#SBATCH --nodes=1
+#SBATCH --nodes=2
 
 #SBATCH --gpus-per-task=8
 
@@ -47,5 +47,5 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 dcgmi profile --pause
 # adjust sbatch --ntasks and sbatch --nodes above and --nnodes below
 # to your specific node count, and update target launch file.
-srun torchrun --nnodes 1 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./test_pipeline_schedule.py --schedules gpipe looped_bfs
+srun torchrun --nnodes 2 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./test_pipeline_schedule.py --schedules gpipe looped_bfs
 dcgmi profile --resume

--- a/test/multinode_trainer.slurm
+++ b/test/multinode_trainer.slurm
@@ -2,9 +2,9 @@
 
 #SBATCH --job-name=test_pipeline_schedules
 
-#SBATCH --ntasks=2
+#SBATCH --ntasks=1
 
-#SBATCH --nodes=2
+#SBATCH --nodes=1
 
 #SBATCH --gpus-per-task=8
 
@@ -47,5 +47,5 @@ export FI_EFA_SET_CUDA_SYNC_MEMOPS=0
 dcgmi profile --pause
 # adjust sbatch --ntasks and sbatch --nodes above and --nnodes below
 # to your specific node count, and update target launch file.
-srun torchrun --nnodes 2 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./test_pipeline_schedule.py --schedules gpipe looped_bfs
+srun torchrun --nnodes 1 --nproc_per_node 8 --rdzv_id 101 --rdzv_backend c10d --rdzv_endpoint "$head_node_ip:29500" ./test_pipeline_schedule.py --schedules gpipe looped_bfs
 dcgmi profile --resume

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -27,6 +27,7 @@ from datetime import timedelta
 
 import torch
 import torch.distributed as dist
+from torch.distributed._tensor.device_mesh import init_device_mesh
 import torch.multiprocessing as mp
 import torch.nn as nn
 from pippy.PipelineSchedule import (
@@ -36,6 +37,7 @@ from pippy.PipelineSchedule import (
     PipelineStageV2Impl,
 )
 from torch.profiler import record_function
+
 
 logger = logging.getLogger(__name__)
 
@@ -97,29 +99,49 @@ class MLP(nn.Module):
         return c
 
 
-def setup(local_rank, world_size):
+def setup(local_rank, init_process_group = False):
     # If this is a child process (i.e., its PID is not the same as the PID of the process that started this script)
     if os.getppid() != os.getpid():
         set_up_logging(local_rank)
 
     # initialize the process group
-    logger.info(f"init for rank {local_rank}")
-    dist.init_process_group("nccl", timeout=timedelta(seconds=20))
-    if torch.distributed.is_initialized():
-        torch.cuda.set_device(local_rank)
+    if init_process_group:
+        logger.info(f"init for rank {local_rank}")
+        dist.init_process_group("nccl", timeout=timedelta(seconds=20))
+        if torch.distributed.is_initialized():
+            torch.cuda.set_device(local_rank)
 
     logger.info(f"finish init for rank {local_rank}")
 
 
 def main(**kwargs):
     torch.manual_seed(42)
+    device = torch.device(kwargs["device"])
+    
+    # use device mesh
+    # create a device mesh based on the given world_size.
+    device_mesh = None
+    rank = None
 
-    rank = kwargs["rank"]
+    if device == 'cuda':
+        device_mesh = init_device_mesh(
+            device_type="cuda", mesh_shape=(int(os.environ["WORLD_SIZE"]),)
+        )
+
+        rank = device_mesh.get_rank()
+        print(f"{device_mesh=}")
+
+
+    if not rank:
+        rank = kwargs["rank"] 
+
     local_rank = kwargs["local_rank"]
     world_size = kwargs["world_size"]
-    device = torch.device(kwargs["device"])
 
-    setup(local_rank, world_size)
+    init_process_group = bool(device_mesh is not None)
+    
+    setup(local_rank, init_process_group= init_process_group )
+
     logger.info(
         f"====== World Rank {rank}, Local Rank {local_rank}, World Size {world_size}, Device {device} main ======"
     )
@@ -249,7 +271,7 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         choices=["gpipe", "looped_bfs", "looped_dfs"],
-        default=["gpipe", "looped_bfs", "looped_dfs"],
+        default=["gpipe",]# "looped_bfs", "looped_dfs"],
     )
     parser.add_argument("--device", type=str, default="cuda")
     args = parser.parse_args()

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -265,9 +265,7 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         choices=["gpipe", "looped_bfs", "looped_dfs"],
-        default=[
-            "gpipe",
-        ],  # "looped_bfs", "looped_dfs"],
+        default=["gpipe", "looped_bfs", "looped_dfs"],
     )
     parser.add_argument("--device", type=str, default="cuda")
     args = parser.parse_args()


### PR DESCRIPTION
## Description
Moves the pipeline scheduler testing to using device_mesh, instead of using init_process_group and torch.cuda.set_device.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Feature/Issue validation/testing
Verified on single node and multi-node. 
