### PR TITLE
Limit torch version in CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch >= 2.2.0.dev
+torch >= 2.2.0.dev, <2.2.0.dev20231212
 packaging >= 21.3


### PR DESCRIPTION
## Description

https://github.com/pytorch/pytorch/pull/115557 moved `_export_to_torch_ir` to `torch.export._trace`. 
Limit our torch version in our CI to avoid a break.

Since https://github.com/pytorch/pytorch/pull/115557 came after PyTorch 2.2 release cut, PyTorch won't have it till 2.3. So once 2.2 is released, we can switch to release version instead of nightly.

Meanwhile, we will be migrating from `_export_to_torch_ir` to `export`. So this version limit is a temporary workaround while we migrate.