### PR TITLE
Support device dispatching during stage creation

### DIFF
--- a/examples/cpu_init/bert_cpu_init.py
+++ b/examples/cpu_init/bert_cpu_init.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+# Minimum effort to run this example:
+# $ torchrun --nproc-per-node 4 bert_cpu_init.py
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.PipelineStage import PipelineStage
+
+from transformers import BertForMaskedLM, BertConfig
+
+
+def add_split_points(bert, nranks):
+    layers_per_rank = bert.config.num_hidden_layers // nranks
+    for i in range(1, nranks):
+        annotate_split_points(
+            bert, {f"bert.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+
+
+def run(args):
+    # Model configs
+    config = BertConfig()
+
+    # Create model on CPU
+    model_class = BertForMaskedLM
+    model_name = "BertForMaskedLM"
+    bert = model_class(config)
+    bert.eval()
+    if args.rank == 0:
+        print(bert.config)
+        print(bert)
+
+    # Example input on CPU
+    example_input = torch.randint(
+        low=0,
+        high=config.vocab_size,
+        size=(args.batch_size, 512),  # bs x seq_len
+        device="cpu",
+        dtype=torch.int64,
+        requires_grad=False,
+    )
+
+    # Annotate split points
+    add_split_points(bert, args.world_size)
+
+    # Create pipeline
+    bert_pipe = Pipe.from_tracing(
+        bert,
+        num_chunks=args.chunks,
+        example_args=(example_input,),
+    )
+    nstages = len(list(bert_pipe.split_gm.children()))
+    assert nstages == args.world_size, f"nstages = {nstages} nranks = {args.world_size}"
+
+    # Create schedule runtime
+    stage = PipelineStage(
+        bert_pipe,
+        args.rank,
+        device=args.device,
+    )
+    stage._move_ops_to_device(args.device)
+
+    # Real input on GPU
+    real_input = torch.randint(
+        low=0,
+        high=config.vocab_size,
+        size=(args.batch_size, 512),  # bs x seq_len
+        device=args.device,
+        dtype=torch.int64,
+        requires_grad=False,
+    )
+
+    # Run
+    if args.rank == 0:
+        stage(real_input)
+    elif args.rank == args.world_size - 1:
+        out = stage()
+    else:
+        stage()
+
+    print(f"Rank {args.rank} completes")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--world_size', type=int, default=int(os.getenv("WORLD_SIZE", 4)))
+    parser.add_argument('--rank', type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument('--master_addr', type=str, default=os.getenv('MASTER_ADDR', 'localhost'))
+    parser.add_argument('--master_port', type=str, default=os.getenv('MASTER_PORT', '29500'))
+    parser.add_argument('--schedule', type=str, default="FillDrain")
+    parser.add_argument('--cuda', type=int, default=int(torch.cuda.is_available()))
+    parser.add_argument("--chunks", type=int, default=4)
+    parser.add_argument('--batch_size', type=int, default=4)
+    parser.add_argument('--batches', type=int, default=1)
+
+    args = parser.parse_args()
+
+    if args.cuda:
+        dev_id = args.rank % torch.cuda.device_count()
+        args.device = torch.device(f"cuda:{dev_id}")
+    else:
+        args.device = torch.device("cpu")
+
+    # Init process group
+    backend = "nccl" if args.cuda else "gloo"
+    dist.init_process_group(
+        backend=backend,
+        rank=args.rank,
+        world_size=args.world_size,
+    )
+
+    run(args)

--- a/examples/cpu_init/bert_cpu_init.py
+++ b/examples/cpu_init/bert_cpu_init.py
@@ -63,7 +63,6 @@ def run(args):
         args.rank,
         device=args.device,
     )
-    stage._move_ops_to_device(args.device)
 
     # Real input on GPU
     real_input = torch.randint(

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -611,9 +611,14 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
                     new_key = k[len(mod_prefix) :]
                     mod_qualname_mapping.setdefault(new_key, v)
             # Add a remap mixin to submodule instance
-            mod.__class__ = type(
-                "PipeStageModule", (QualnameMapMixin, mod.__class__), {}
-            )
+            # TODO: this class change is commented out because it breaks
+            # recompilation if we want to recompile mod after. For example, we
+            # may recompile mod to modify the "device" kwarg of a `torch.ones`
+            # node (trace on cpu/meta, run on cuda).
+            # See: https://github.com/pytorch/vision/issues/5826
+            # mod.__class__ = type(
+            #     "PipeStageModule", (QualnameMapMixin, mod.__class__), {}
+            # )
             setattr(mod, "new_to_old_qualname_mapping", mod_qualname_mapping)
 
         def throw(self, *args, **kwargs):

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -140,11 +140,10 @@ class PipelineStage(torch.nn.Module):
         # Note: we cannot move meta module to real devices because meta tensors
         # do not support to() method. One needs to do an in-place tensor swap in
         # that case.
-        has_meta_param = False
-        for k, v in self.submod.named_parameters():
-            if isinstance(v, FakeTensor) or v.is_meta:
-                has_meta_param = True
-                break
+        has_meta_param = any(
+            isinstance(p, FakeTensor) or p.is_meta
+            for p in self.submod.parameters()
+        )
         if has_meta_param:
             logger.debug(f"[{self.group_rank}] Found meta parameters!")
         else:

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -83,11 +83,11 @@ def modify_graph_op_device(
     modified = False
     for node in gm.graph.nodes:
         if node.op == "call_function":
-            if "device" in node.kwargs:
-                node.update_kwarg("device", new_device)
+            if "device" in node.kwargs and node.kwargs["device"] != new_device:
                 logger.debug(
-                    f"Changed device of Node {node.name} to {new_device}"
+                    f"Changing device of Node {node.name} from {node.kwargs['device']} to {new_device}"
                 )
+                node.update_kwarg("device", new_device)
                 modified = True
 
     if modified:

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
+
 import torch
 import torch.distributed as dist
 from torch import fx

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -1,7 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import logging
 import torch
 import torch.distributed as dist
 from torch import fx
+
+
+logger = logging.getLogger(__name__)
 
 
 def flatten_args_detach(args):
@@ -69,3 +73,21 @@ def _get_binary_filename(cur_idx: int, is_optim: bool = False) -> str:  # type: 
     state_type = "optim" if is_optim else "model"
 
     return f"pytorch_{state_type}-{idx}-of-{world_size}.bin"
+
+
+def modify_graph_op_device(
+    gm: torch.fx.GraphModule,
+    new_device: torch.device,
+):
+    modified = False
+    for node in gm.graph.nodes:
+        if node.op == "call_function":
+            if "device" in node.kwargs:
+                node.update_kwarg("device", new_device)
+                logger.debug(
+                    f"Changed device of Node {node.name} to {new_device}"
+                )
+                modified = True
+
+    if modified:
+        gm.recompile()

--- a/test/test_cpu_init.py
+++ b/test/test_cpu_init.py
@@ -56,11 +56,6 @@ def run_worker(args):
         device=args.device,
     )
 
-    # Today the tracer does not treat `x.device` as a symbolic device; instead,
-    # "cpu" got burned into the traced code.  We need to manually modify the
-    # "device" kwarg of `torch.ones` here.
-    stage._move_ops_to_device(args.device)
-
     # Create real input on real device
     x = torch.randn(batch_size, d_hid, device=args.device)
 

--- a/test/test_cpu_init.py
+++ b/test/test_cpu_init.py
@@ -26,6 +26,9 @@ class ExampleCode(torch.nn.Module):
         self.lin = torch.nn.Linear(d_hid, d_hid)
 
     def forward(self, x):
+        # Test change of tensor creation device after tracing
+        a = torch.ones(batch_size, d_hid, device=x.device)
+        x = x + a
         x = torch.mm(x, self.mm_param)
         x = torch.relu(x)
         pipe_split()
@@ -52,6 +55,11 @@ def run_worker(args):
         args.rank,
         device=args.device,
     )
+
+    # Today the tracer does not treat `x.device` as a symbolic device; instead,
+    # "cpu" got burned into the traced code.  We need to manually modify the
+    # "device" kwarg of `torch.ones` here.
+    stage._move_ops_to_device(args.device)
 
     # Create real input on real device
     x = torch.randn(batch_size, d_hid, device=args.device)

--- a/test/test_cpu_init.py
+++ b/test/test_cpu_init.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import argparse
+import os
+import unittest
+
+import pippy
+
+import torch
+import torch.distributed as dist
+from pippy.IR import Pipe, pipe_split
+from pippy.PipelineStage import PipelineStage
+
+
+pippy.microbatch._debug_mask_minibatches = True
+
+d_hid = 512
+batch_size = 256
+
+torch.manual_seed(0)
+
+
+class ExampleCode(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x):
+        x = torch.mm(x, self.mm_param)
+        x = torch.relu(x)
+        pipe_split()
+        x = self.lin(x)
+        x = torch.relu(x)
+        return x
+
+
+def run_worker(args):
+    # Create module and trace model in CPU
+    mod = ExampleCode()
+
+    xe = torch.randn(batch_size, d_hid)
+
+    pipe = Pipe.from_tracing(
+        mod,
+        args.chunks,
+        example_args=(xe,),
+    )
+
+    # Create pipeline stages and move stage to GPU
+    stage = PipelineStage(
+        pipe,
+        args.rank,
+        device=args.device,
+    )
+
+    # Create real input on real device
+    x = torch.randn(batch_size, d_hid, device=args.device)
+
+    # Run
+    if args.rank == 0:
+        stage(x)
+    elif args.rank == args.world_size - 1:
+        out = stage()
+    else:
+        stage()
+
+    dist.barrier()
+    print(f"Rank {args.rank} completes")
+
+    # Last rank checks result
+    if args.rank == args.world_size - 1:
+        mod.to(args.device)
+        ref_out = mod(x)
+        torch.testing.assert_close(out, ref_out)
+        print(
+            f"equivalence test passed {torch.sum(out)} ref {torch.sum(ref_out)}"
+        )
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size", type=int, default=int(os.getenv("WORLD_SIZE", 2))
+    )
+    parser.add_argument("--rank", type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument(
+        "--master_addr", type=str, default=os.getenv("MASTER_ADDR", "localhost")
+    )
+    parser.add_argument(
+        "--master_port", type=str, default=os.getenv("MASTER_PORT", "29500")
+    )
+    parser.add_argument(
+        "--cuda", type=int, default=int(torch.cuda.is_available())
+    )
+    parser.add_argument(
+        "--chunks",
+        type=int,
+        default=4,
+    )
+    args = parser.parse_args(args)
+
+    if args.cuda:
+        dev_id = args.rank % torch.cuda.device_count()
+        args.device = torch.device(f"cuda:{dev_id}")
+    else:
+        args.device = torch.device("cpu")
+
+    # Init process group
+    backend = "nccl" if args.cuda else "gloo"
+    dist.init_process_group(
+        backend=backend,
+        rank=args.rank,
+        world_size=args.world_size,
+    )
+
+    run_worker(args)
+
+
+if __name__ == "__main__":
+    main()
+
+
+class TestFwd(unittest.TestCase):
+    def test_fwd(self):
+        import random
+
+        port = random.randint(29500, 30000)
+        args = [
+            "--master_port",
+            str(port),
+        ]
+        main(args)


### PR DESCRIPTION
## Description

This PR adds support to a case where the user creates model and trace model on CPU, then creates pipeline stage on GPU.
PiPPy would move only the stage module to the corresponding GPU.

## Test
```
torchrun --nproc-per-node 2 test_cpu_init.py
```

## Update:
Sometimes, the `forward` function of user code may create constant tensors based on input device:
```
device = input_ids.device
attention_mask = torch.ones(…, device=device)
```
As of now, PT2 tracer does not treat `input_ids.device` as a symbolic device. As a result, `device="cpu"` got burned in the generated code:
```
ones = torch.ones(…, device = device(type='cpu'))
```
To workaround this, this PR added call in `PipelineStage` creation:
```
def _move_ops_to_device(new_device)
```
After this call, the `device=` kwarg of `torch.ones` will be modified to the `new_device`.
This call is hidden from user, thus when symbolic device support is added, we can silently remove this and not involve user code change.

We also checked native_functions.yaml, all APIs involving the "device" kwarg are generator ops, which are safe to change the device value. (And we should).

## Real Example
```
cd examples/cpu_init
torchrun --nproc-per-node 4 bert_cpu_init.py
```
 
Cc: @muellerzr @SunMarc