### PR TITLE
add get_stage_shapes() and validate_stage_shapes() helpers

### DIFF
--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -3,11 +3,19 @@
 import unittest
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
-from pippy.PipelineSchedule import PipelineStageV2Impl
+from pippy.PipelineSchedule import (
+    create_metadata_tensor,
+    extract_metadata_from_tensor,
+    get_stage_shapes,
+    PipelineStageV2Impl,
+    validate_stage_shapes,
+)
 
 # torch.testing._internal.common_distributed requies "expecttest"
 from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import FILE_SCHEMA
 
 # Example models and helper utils
 ##########################
@@ -90,21 +98,42 @@ class TestPipelineSchedule(MultiProcessTestCase):
         # covers first_stage, middle_stage, last_stage cases
         return 3
 
+    @property
+    def init_method(self) -> str:
+        return f"{FILE_SCHEMA}{self.file_name}"
+
     def setUp(self):
         super().setUp()
         # starts world_size processes
         self._spawn_processes()
 
-    def _create_pipline_stage(self, model, inputs, device):
+    def _create_pipline_stage(
+        self, model, inputs, device, stage_id=None, num_stages=None
+    ):
         return PipelineStageV2Impl(
             module=model,
-            stage_id=self.rank,
-            num_stages=self.world_size,
+            stage_id=self.rank if stage_id is None else stage_id,
+            num_stages=self.world_size if num_stages is None else num_stages,
             rank=self.rank,
             world_size=self.world_size,
             input_args=inputs,
             device=device,
         )
+
+    def _create_virtual_pipeline_stages(
+        self, model, inputs, device, virtual_size
+    ):
+        virtual_stages = []
+        for i in range(virtual_size):
+            stage = self._create_pipline_stage(
+                model,
+                inputs,
+                device,
+                self.rank + (i * self.world_size),
+                self.world_size * virtual_size,
+            )
+            virtual_stages.append(stage)
+        return virtual_stages
 
     def test_pipeline_stage_init(self):
         # TODO: parameterize the device?
@@ -113,11 +142,11 @@ class TestPipelineSchedule(MultiProcessTestCase):
         model = MLP(dim=8, hidden_dim=4, out_dim=4)
         inputs = torch.rand((2, 8), device=device)
         self._create_pipline_stage(model, inputs, device)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             invalid_input_args = {"foo": "bar"}
             self._create_pipline_stage(model, invalid_input_args, device)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             invalid_model = InvalidOutputModel()
             self._create_pipline_stage(invalid_model, inputs, device)
 
@@ -130,7 +159,10 @@ class TestPipelineSchedule(MultiProcessTestCase):
         input1 = torch.rand((2, 8), device=device)
         pipeline_stage = self._create_pipline_stage(model, input1, device)
         output = pipeline_stage(input1)
-        self.assertEqual(output.shape, torch.Size([2, 4]))
+        if self.rank == self.world_size - 1:
+            self.assertIsInstance(output, torch.Tensor)
+        else:
+            self.assertEqual(output.shape, torch.Size([2, 4]))
 
         # multi-input model forward
         model = MultiInputArgMLP(dim1=8, dim2=4, out_dim=4)
@@ -140,16 +172,119 @@ class TestPipelineSchedule(MultiProcessTestCase):
             model, [input1, input2], device
         )
         output = pipeline_stage([input1, input2])
-        self.assertEqual(output.shape, torch.Size([2, 4]))
+        if self.rank == self.world_size - 1:
+            self.assertIsInstance(output, torch.Tensor)
+        else:
+            self.assertEqual(output.shape, torch.Size([2, 4]))
 
         # multi-output model forward
         model = MultiOutputArgMLP(dim=8, out_dim=4)
         input1 = torch.rand((2, 8), device=device)
         pipeline_stage = self._create_pipline_stage(model, input1, device)
         output = pipeline_stage(input1)
-        self.assertEqual(len(output), 2)
-        self.assertEqual(output[0].shape, torch.Size([2, 4]))
-        self.assertEqual(output[1].shape, torch.Size([4, 4]))
+        if self.rank == self.world_size - 1:
+            self.assertIsInstance(output, torch.Tensor)
+        else:
+            self.assertEqual(len(output), 2)
+            self.assertEqual(output[0].shape, torch.Size([2, 4]))
+            self.assertEqual(output[1].shape, torch.Size([4, 4]))
+
+    def test_get_stage_shapes(self):
+        device = "cpu"
+        dist.init_process_group(
+            init_method=self.init_method,
+            backend="gloo",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        model_chunk = MLP(dim=8, hidden_dim=4, out_dim=8)
+        microbatch = torch.rand((10, 8), device=device)
+        # test single model
+        stages_shapes = get_stage_shapes(
+            models=[model_chunk],
+            stage_ids=[self.rank],
+            num_stages=self.world_size,
+            rank=self.rank,
+            world_size=self.world_size,
+            device=device,
+            microbatch=microbatch if self.rank == 0 else None,
+        )
+        self.assertEqual(len(stages_shapes), 1)
+        shapes = stages_shapes[self.rank]
+        self.assertEqual(len(shapes), 2)
+        self.assertEqual(shapes["inputs"], [torch.Size([10, 8])])
+        self.assertEqual(shapes["outputs"], [torch.Size([10, 8])])
+
+        # test multiple models (multiple stages)
+        model_chunk1 = MLP(dim=8, hidden_dim=4, out_dim=8)
+        model_chunk2 = MLP(dim=8, hidden_dim=4, out_dim=8)
+        stages_shapes = get_stage_shapes(
+            models=[model_chunk1, model_chunk2],
+            stage_ids=[self.rank, self.rank + self.world_size],
+            num_stages=self.world_size * 2,
+            rank=self.rank,
+            world_size=self.world_size,
+            device=device,
+            microbatch=microbatch if self.rank == 0 else None,
+        )
+        self.assertEqual(len(stages_shapes), 2)
+        self.assertEqual(len(stages_shapes[self.rank]), 2)
+        shapes = stages_shapes[self.rank + self.world_size]
+        self.assertEqual(shapes["inputs"], [torch.Size([10, 8])])
+        self.assertEqual(shapes["outputs"], [torch.Size([10, 8])])
+
+    def test_validate_stage_shapes(self):
+        device = "cpu"
+        dist.init_process_group(
+            init_method=self.init_method,
+            backend="gloo",
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        # test single pipeline stage
+        model_chunk = MLP(dim=8, hidden_dim=4, out_dim=8)
+        input1 = torch.rand((4, 8), device=device)
+        pipeline_stage = self._create_pipline_stage(model_chunk, input1, device)
+        validate_stage_shapes([pipeline_stage])
+
+        # test multiple pipeline stages
+        model_chunk = MLP(dim=2, hidden_dim=2, out_dim=2)
+        input1 = torch.rand((5, 2), device=device)
+        stages = self._create_virtual_pipeline_stages(
+            model_chunk, input1, device, 2
+        )
+        validate_stage_shapes(stages)
+
+        # mismatched model chunk case
+        with self.assertRaises(ValueError):
+            if self.rank == 1:
+                model_chunk = MLP(dim=2, hidden_dim=4, out_dim=6)
+            pipeline_stage = self._create_pipline_stage(
+                model_chunk, input1, device
+            )
+            validate_stage_shapes([pipeline_stage])
+
+
+class UtilTest(unittest.TestCase):
+    def test_metadata_tensor(self):
+        # scalar
+        t1 = torch.tensor(1)
+        # 1d (3)
+        t2 = torch.tensor([1, 2, 3])
+        # 2d (2x3)
+        t3 = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        # n-d
+        t4 = torch.ones((3, 4, 5, 6))
+
+        metadata_tensor = create_metadata_tensor([t1, t2, t3, t4])
+        shapes = extract_metadata_from_tensor(metadata_tensor)
+
+        self.assertEqual(shapes[0], t1.shape)
+        self.assertEqual(shapes[1], t2.shape)
+        self.assertEqual(shapes[2], t3.shape)
+        self.assertEqual(shapes[3], t4.shape)
 
 
 if __name__ == "__main__":

--- a/test/test_pipeline_schedule_e2e.py
+++ b/test/test_pipeline_schedule_e2e.py
@@ -166,12 +166,12 @@ def main(**kwargs):
 
     stage_model = PipelineStageV2Impl(
         module_list[rank],
-        rank,
-        world_size,
-        rank,
-        world_size,
-        input_args,
-        device,
+        stage_id=rank,
+        num_stages=world_size,
+        rank=rank,
+        world_size=world_size,
+        device=device,
+        input_args=input_args,
     )
     stage_model.init_p2p_neighbors()
 
@@ -182,8 +182,8 @@ def main(**kwargs):
             num_stages=world_size * world_size,
             rank=rank,
             world_size=world_size,
-            input_args=input_args,
             device=device,
+            input_args=input_args,
         )
         for i in range(world_size)
     ]


### PR DESCRIPTION
fixes #946

Update and simplifies some variable naming in `PipelineStage`

Add two helper functions:
- add `get_stage_shapes` which  passes a single microbatch through all the model_chunks and returns the inputs and outputs for each model_chunk.
- add `validate_stage_shapes ` which validates that the input and output for each pipeline stage can be communicated and the neighboring stages shapes are valid.

To implement these I needed to create a predefined format that ranks could communicate with as they transfer shapes to each other. The data is of format `[num_dims, dim1, dim2, ...]`, for example if the inputs are `[torch.ones((4,5)), torch.zeros(2,4,1)]`, then the metadata tensor would look like `[2, 4, 5, 3, 2, 4, 1, 0, 0, ...]` (rest are 0s). See `create_metadata_tensor` and `extract_metadata_from_tensor` implementations.