### PR TITLE
Retire PipeSplitWrapper and support UNet tracing

### DIFF
--- a/examples/huggingface/pippy_albert.py
+++ b/examples/huggingface/pippy_albert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import AlbertForMaskedLM, AlbertConfig
@@ -20,7 +20,7 @@ from hf_utils import generate_inputs_for_model, get_number_of_params
 def add_split_points(albert, nranks):
     albert_layer_fqn = "albert.encoder.albert_layer_groups.0.albert_layers.0"
     annotate_split_points(
-        albert, {albert_layer_fqn: PipeSplitWrapper.SplitPoint.BEGINNING})
+        albert, {albert_layer_fqn: SplitPoint.BEGINNING})
     # Because of the for loop structure in albert's forward method, this will
     # split the albert model `num_hidden_layers` times (hence
     # `num_hidden_layers`+1 stages)

--- a/examples/huggingface/pippy_bart.py
+++ b/examples/huggingface/pippy_bart.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BartForCausalLM, BartConfig
@@ -21,7 +21,7 @@ def add_split_points(bart, nranks):
     layers_per_rank = bart.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            bart, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            bart, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_bert.py
+++ b/examples/huggingface/pippy_bert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BertForMaskedLM, BertConfig
@@ -21,7 +21,7 @@ def add_split_points(bert, nranks):
     layers_per_rank = bert.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            bert, {f"bert.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            bert, {f"bert.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_blenderbot.py
+++ b/examples/huggingface/pippy_blenderbot.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BlenderbotForCausalLM, BlenderbotConfig
@@ -21,7 +21,7 @@ def add_split_points(blenderbot, nranks):
     layers_per_rank = blenderbot.config.decoder_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            blenderbot, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            blenderbot, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_camemBert.py
+++ b/examples/huggingface/pippy_camemBert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import CamembertForMaskedLM, CamembertConfig
@@ -21,7 +21,7 @@ def add_split_points(camembert, nranks):
     layers_per_rank = camembert.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            camembert, {f"roberta.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            camembert, {f"roberta.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_deberta.py
+++ b/examples/huggingface/pippy_deberta.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DebertaForMaskedLM, DebertaConfig
@@ -21,7 +21,7 @@ def add_split_points(deberta, nranks):
     layers_per_rank = deberta.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            deberta, {f"deberta.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            deberta, {f"deberta.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_debertaV2.py
+++ b/examples/huggingface/pippy_debertaV2.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DebertaV2ForMaskedLM, DebertaConfig
@@ -21,7 +21,7 @@ def add_split_points(deberta, nranks):
     layers_per_rank = deberta.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            deberta, {f"deberta.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            deberta, {f"deberta.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_distilBert.py
+++ b/examples/huggingface/pippy_distilBert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DistilBertForMaskedLM, DistilBertConfig
@@ -20,12 +20,12 @@ from hf_utils import generate_inputs_for_model, get_number_of_params
 def add_split_points(distilbert, nranks):
     # The first rank carries the embedding layer
     annotate_split_points(
-        distilbert, {f"distilbert.embeddings": PipeSplitWrapper.SplitPoint.END})
+        distilbert, {f"distilbert.embeddings": SplitPoint.END})
     # 6 Transformer layers divided over the rest 3 ranks
     layers_per_rank = distilbert.config.num_hidden_layers // (nranks - 1)
     for i in range(1, nranks - 1):
         annotate_split_points(
-            distilbert, {f"distilbert.transformer.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            distilbert, {f"distilbert.transformer.layer.{i * layers_per_rank}": PipeSplitWrapper.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_electra.py
+++ b/examples/huggingface/pippy_electra.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import ElectraForCausalLM, ElectraConfig
@@ -21,7 +21,7 @@ def add_split_points(electra, nranks):
     layers_per_rank = electra.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            electra, {f"electra.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            electra, {f"electra.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_fnet.py
+++ b/examples/huggingface/pippy_fnet.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import FNetForMaskedLM, FNetConfig
@@ -21,7 +21,7 @@ def add_split_points(fnet, nranks):
     layers_per_rank = fnet.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            fnet, {f"fnet.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            fnet, {f"fnet.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_gpt2.py
+++ b/examples/huggingface/pippy_gpt2.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import GPT2ForSequenceClassification, GPT2Config
@@ -24,7 +24,7 @@ def add_split_points(gpt2, nranks):
     for i in range(1, gpt2.config.n_layer // decoders_per_rank):
         annotate_split_points(
             gpt2,
-            {f'transformer.h.{i * decoders_per_rank}': PipeSplitWrapper.SplitPoint.BEGINNING},
+            {f'transformer.h.{i * decoders_per_rank}': SplitPoint.BEGINNING},
         )
         nstages += 1
     assert nstages == nranks, f"nstages = {nstages} nranks = {nranks}"

--- a/examples/huggingface/pippy_gptNeo.py
+++ b/examples/huggingface/pippy_gptNeo.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import GPTNeoForCausalLM, GPTNeoConfig
@@ -21,7 +21,7 @@ def add_split_points(gptneo, nranks):
     layers_per_rank = gptneo.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            gptneo, {f"transformer.h.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            gptneo, {f"transformer.h.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_m2m100.py
+++ b/examples/huggingface/pippy_m2m100.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import M2M100ForConditionalGeneration, M2M100Config
@@ -20,10 +20,10 @@ from hf_utils import generate_inputs_for_model, get_number_of_params
 def add_split_points(m2m100, nranks):
     # First rank takes encoder
     annotate_split_points(
-        m2m100, {"model.encoder": PipeSplitWrapper.SplitPoint.END})
+        m2m100, {"model.encoder": SplitPoint.END})
     # Second rank takes decoder
     annotate_split_points(
-        m2m100, {"model.decoder": PipeSplitWrapper.SplitPoint.END})
+        m2m100, {"model.decoder": SplitPoint.END})
     # Last rank takes LM head
 
 

--- a/examples/huggingface/pippy_mbart.py
+++ b/examples/huggingface/pippy_mbart.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MBartForCausalLM, MBartConfig
@@ -21,7 +21,7 @@ def add_split_points(mbart, nranks):
     layers_per_rank = mbart.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            mbart, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            mbart, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_megatronBert.py
+++ b/examples/huggingface/pippy_megatronBert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MegatronBertForCausalLM, MegatronBertConfig
@@ -21,7 +21,7 @@ def add_split_points(bert, nranks):
     layers_per_rank = bert.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            bert, {f"bert.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            bert, {f"bert.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_mobileBert.py
+++ b/examples/huggingface/pippy_mobileBert.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MobileBertForMaskedLM, MobileBertConfig
@@ -20,12 +20,12 @@ from hf_utils import generate_inputs_for_model, get_number_of_params
 def add_split_points(mobilebert, nranks):
     # The last rank carries LM head
     annotate_split_points(
-        mobilebert, {"cls": PipeSplitWrapper.SplitPoint.BEGINNING})
+        mobilebert, {"cls": SplitPoint.BEGINNING})
     # The rest ranks divide the 24 layers
     layers_per_rank = mobilebert.config.num_hidden_layers // (nranks - 1)
     for i in range(1, nranks - 1):
         annotate_split_points(
-            mobilebert, {f"mobilebert.encoder.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            mobilebert, {f"mobilebert.encoder.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_mt5.py
+++ b/examples/huggingface/pippy_mt5.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MT5ForConditionalGeneration, MT5Config
@@ -28,16 +28,16 @@ def add_split_points(mt5, nranks):
     # Split encoder
     for i in range(1, mt5.config.num_layers // layers_per_rank):
         annotate_split_points(
-            mt5, {f'encoder.block.{i * layers_per_rank}': PipeSplitWrapper.SplitPoint.BEGINNING})
+            mt5, {f'encoder.block.{i * layers_per_rank}': SplitPoint.BEGINNING})
         nstages += 1
     # Split at the boundary of encoder and decoder
     annotate_split_points(
-        mt5, {f'decoder.embed_tokens': PipeSplitWrapper.SplitPoint.BEGINNING})
+        mt5, {f'decoder.embed_tokens': SplitPoint.BEGINNING})
     nstages += 1
     # Split decoder
     for i in range(1, mt5.config.num_decoder_layers // layers_per_rank):
         annotate_split_points(
-            mt5, {f'decoder.block.{i * layers_per_rank}': PipeSplitWrapper.SplitPoint.BEGINNING})
+            mt5, {f'decoder.block.{i * layers_per_rank}': SplitPoint.BEGINNING})
         nstages += 1
     assert nstages == nranks, f"nstages = {nstages} nranks = {nranks}"
 

--- a/examples/huggingface/pippy_opt.py
+++ b/examples/huggingface/pippy_opt.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import OPTForCausalLM, OPTConfig
@@ -21,7 +21,7 @@ def add_split_points(opt, nranks):
     layers_per_rank = opt.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            opt, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            opt, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_pegasus.py
+++ b/examples/huggingface/pippy_pegasus.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import PegasusForCausalLM, PegasusConfig
@@ -21,7 +21,7 @@ def add_split_points(pegasus, nranks):
     layers_per_rank = pegasus.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            pegasus, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            pegasus, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_t5.py
+++ b/examples/huggingface/pippy_t5.py
@@ -10,7 +10,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import T5ForConditionalGeneration, T5Config
@@ -29,16 +29,16 @@ def add_split_points(t5, nranks):
     # Split encoder
     for i in range(1, t5.config.num_layers // layers_per_rank):
         annotate_split_points(
-            t5, {f'encoder.block.{i * layers_per_rank}': PipeSplitWrapper.SplitPoint.BEGINNING})
+            t5, {f'encoder.block.{i * layers_per_rank}': SplitPoint.BEGINNING})
         nstages += 1
     # Split at the boundary of encoder and decoder
     annotate_split_points(
-        t5, {f'decoder.embed_tokens': PipeSplitWrapper.SplitPoint.BEGINNING})
+        t5, {f'decoder.embed_tokens': SplitPoint.BEGINNING})
     nstages += 1
     # Split decoder
     for i in range(1, t5.config.num_decoder_layers // layers_per_rank):
         annotate_split_points(
-            t5, {f'decoder.block.{i * layers_per_rank}': PipeSplitWrapper.SplitPoint.BEGINNING})
+            t5, {f'decoder.block.{i * layers_per_rank}': SplitPoint.BEGINNING})
         nstages += 1
     assert nstages == nranks, f"nstages = {nstages} nranks = {nranks}"
 

--- a/examples/huggingface/pippy_trOCR.py
+++ b/examples/huggingface/pippy_trOCR.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import TrOCRForCausalLM, TrOCRConfig
@@ -21,7 +21,7 @@ def add_split_points(trocr, nranks):
     layers_per_rank = trocr.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            trocr, {f"model.decoder.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            trocr, {f"model.decoder.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/huggingface/pippy_unet.py
+++ b/examples/huggingface/pippy_unet.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from diffusers import UNet2DModel
@@ -37,7 +37,7 @@ def run(args):
     # Split model into two stages:
     #   Stage 0: down_blocks + mid_block
     #   Stage 2: up_blocks
-    annotate_split_points(unet, {"mid_block": PipeSplitWrapper.SplitPoint.END})
+    annotate_split_points(unet, {"mid_block": SplitPoint.END})
 
     # Create pipeline
     unet_pipe = Pipe.from_tracing(

--- a/examples/huggingface/pippy_xlnet.py
+++ b/examples/huggingface/pippy_xlnet.py
@@ -9,7 +9,7 @@ import os
 import torch
 import torch.distributed as dist
 
-from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.IR import Pipe, SplitPoint, annotate_split_points
 from pippy.PipelineStage import PipelineStage
 
 from transformers import XLNetLMHeadModel, XLNetConfig
@@ -21,7 +21,7 @@ def add_split_points(xlnet, nranks):
     layers_per_rank = xlnet.config.num_hidden_layers // nranks
     for i in range(1, nranks):
         annotate_split_points(
-            xlnet, {f"transformer.layer.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+            xlnet, {f"transformer.layer.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 
 def run(args):

--- a/examples/llama/pippy_llama.py
+++ b/examples/llama/pippy_llama.py
@@ -2,7 +2,7 @@
 import os
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from pippy import Pipe, PipeSplitWrapper, annotate_split_points, PipelineStage
+from pippy import Pipe, SplitPoint, annotate_split_points, PipelineStage
 
 # Grab the model
 llama = AutoModelForCausalLM.from_pretrained(
@@ -26,7 +26,7 @@ inputs = tokenizer(prompts, return_tensors="pt", padding=True).to(device)
 layers_per_rank = llama.config.num_hidden_layers // world_size
 for i in range(1, world_size):
     annotate_split_points(llama,
-        {f"model.layers.{i * layers_per_rank}": PipeSplitWrapper.SplitPoint.BEGINNING})
+        {f"model.layers.{i * layers_per_rank}": SplitPoint.BEGINNING})
 
 # Create a pipeline representation from the model
 llama_pipe = Pipe.from_tracing(llama, world_size, example_args=(inputs["input_ids"],))

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -1193,12 +1193,12 @@ class PipeSplitWrapper:
 
 def _split_before_forwad(self, *args, **kwargs):
     pipe_split()
-    return self.orig_forward(*args, **kwargs)
+    return self._orig_forward(*args, **kwargs)
 
 
 def _split_after_forwad(self, *args, **kwargs):
     try:
-        return self.orig_forward(*args, **kwargs)
+        return self._orig_forward(*args, **kwargs)
     finally:
         pipe_split()
 
@@ -1217,7 +1217,7 @@ def annotate_split_points(mod: torch.nn.Module, spec: Dict[str, SplitPoint]):
                 )
 
         mod_to_wrap = getattr(predecessor_module, atoms[-1])
-        mod_to_wrap.orig_forward = mod_to_wrap.forward
+        mod_to_wrap._orig_forward = mod_to_wrap.forward
         if split_type == SplitPoint.BEGINNING:
             mod_to_wrap.forward = MethodType(_split_before_forwad, mod_to_wrap)
         elif split_type == SplitPoint.END:

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -1191,12 +1191,12 @@ class PipeSplitWrapper:
     SplitPoint = SplitPoint
 
 
-def _split_before_forwad(self, *args, **kwargs):
+def _split_before_forward(self, *args, **kwargs):
     pipe_split()
     return self._orig_forward(*args, **kwargs)
 
 
-def _split_after_forwad(self, *args, **kwargs):
+def _split_after_forward(self, *args, **kwargs):
     try:
         return self._orig_forward(*args, **kwargs)
     finally:
@@ -1219,9 +1219,9 @@ def annotate_split_points(mod: torch.nn.Module, spec: Dict[str, SplitPoint]):
         mod_to_wrap = getattr(predecessor_module, atoms[-1])
         mod_to_wrap._orig_forward = mod_to_wrap.forward
         if split_type == SplitPoint.BEGINNING:
-            mod_to_wrap.forward = MethodType(_split_before_forwad, mod_to_wrap)
+            mod_to_wrap.forward = MethodType(_split_before_forward, mod_to_wrap)
         elif split_type == SplitPoint.END:
-            mod_to_wrap.forward = MethodType(_split_after_forwad, mod_to_wrap)
+            mod_to_wrap.forward = MethodType(_split_after_forward, mod_to_wrap)
         else:
             raise ValueError("Unknown split point type.")
 

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -4,6 +4,7 @@ import logging
 import operator
 from enum import Enum
 from inspect import Parameter, signature, Signature
+from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -1178,34 +1179,31 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
         return param_buffer_table
 
 
-class PipeSplitWrapper(torch.nn.Module):
-    class SplitPoint(Enum):
-        BEGINNING = 1
-        END = 2
-
-    def __init__(
-        self,
-        mod: torch.nn.Module,
-        split_point: SplitPoint = SplitPoint.BEGINNING,
-    ):
-        super().__init__()
-        self.mod = mod
-        self.split_point = split_point
-
-    def forward(self, *args, **kwargs):
-        try:
-            if self.split_point == self.SplitPoint.BEGINNING:
-                pipe_split()
-
-            return self.mod(*args, **kwargs)
-        finally:
-            if self.split_point == self.SplitPoint.END:
-                pipe_split()
+class SplitPoint(Enum):
+    BEGINNING = 1
+    END = 2
 
 
-def annotate_split_points(
-    mod: torch.nn.Module, spec: Dict[str, PipeSplitWrapper.SplitPoint]
-):
+# For backward compatibility, we kept the PipeSplitWrapper class because `class
+# SplitPoint` used to be defined in this class.
+class PipeSplitWrapper:
+    # Create a class alias for BC
+    SplitPoint = SplitPoint
+
+
+def _split_before_forwad(self, *args, **kwargs):
+    pipe_split()
+    return self.orig_forward(*args, **kwargs)
+
+
+def _split_after_forwad(self, *args, **kwargs):
+    try:
+        return self.orig_forward(*args, **kwargs)
+    finally:
+        pipe_split()
+
+
+def annotate_split_points(mod: torch.nn.Module, spec: Dict[str, SplitPoint]):
     # TODO: make this implementation out-of-place?
     for qualname, split_type in spec.items():
         atoms = qualname.split(".")
@@ -1219,8 +1217,13 @@ def annotate_split_points(
                 )
 
         mod_to_wrap = getattr(predecessor_module, atoms[-1])
-        wrapped_mod = PipeSplitWrapper(mod_to_wrap, split_type)
-        setattr(predecessor_module, atoms[-1], wrapped_mod)
+        mod_to_wrap.orig_forward = mod_to_wrap.forward
+        if split_type == SplitPoint.BEGINNING:
+            mod_to_wrap.forward = MethodType(_split_before_forwad, mod_to_wrap)
+        elif split_type == SplitPoint.END:
+            mod_to_wrap.forward = MethodType(_split_after_forwad, mod_to_wrap)
+        else:
+            raise ValueError("Unknown split point type.")
 
 
 class PipeFakeTensorProp(Interpreter):

--- a/pippy/__init__.py
+++ b/pippy/__init__.py
@@ -6,6 +6,7 @@ from pippy.IR import (
     pipe_split,
     PipeSequential,
     PipeSplitWrapper,
+    SplitPoint,
     TrivialLossWrapper,
 )
 from pippy.ModelSplit import split_into_equal_size, split_on_size_threshold
@@ -20,6 +21,7 @@ __all__ = [
     "PipelineStage",
     "pipe_split",
     "PipeSplitWrapper",
+    "SplitPoint",
     "annotate_split_points",
     "split_into_equal_size",
     "split_on_size_threshold",


### PR DESCRIPTION
`PipeSplitWrapper` is our current way of adding split annotation. 

However, it adds a `self.mod` hierarchy (due to wrapping), which:
- causes trouble for tracing certain model (e.g. UNet directly access `up_block0.resnet` from the root's forward; if `up_block0` is turned into a `PipeSplitWrapper`, then resnet's FQN becomes `up_block0.mod.resnet`, making `up_block0.resnet` an "attribute not found".
- makes it harder to maintain FQN invariance which distributed checkpointing prefers.

This PR replaces the wrapping method with one that swaps the forward function of the wrapped module, so that `self.mod = wrapped_mod` is not needed.