### PR TITLE
Drop support of receiving activation in kwargs form

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -75,7 +75,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        schedule: ["FillDrain"]
     env:
       OMP_NUM_THREADS: "1"
     container:
@@ -96,8 +95,6 @@ jobs:
         run: python test/test_pipe_bwd.py
       - name: Run forward-only integration test
         run: torchrun --nproc-per-node 4 test/test_fwd.py
-      - name: Run forward-loss-backward integration test
-        run: torchrun --nproc-per-node 4 test/test_bwd.py --schedule ${{ matrix.schedule }}
       - name: Run example
         run: torchrun --nproc-per-node 3 examples/basic/example.py
       - name: Run auto-split test

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -79,8 +79,8 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
         # map microbatch ID to list of forward tensor args
         self.fwd_cache: Dict[int, Tuple[Any, List[torch.Tensor]]] = {}
         # Split input chunks
-        self.args_split = None
-        self.kwargs_split = None
+        self.args_split: List = []
+        self.kwargs_split: List = []
         # Activation send requests of all chunk
         self.all_act_send_reqs: List[dist.Work] = []
         # Grad send requests of all chunk
@@ -188,13 +188,8 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
         """
         # chunk : Tuple of arg buffers
         self.args_recv_info: Dict[int, Tuple] = {}
-        # chunk : Dict of kwarg buffers
-        self.kwargs_recv_info: Dict[int, Dict] = {}
         for chunk in range(self.chunks):
-            (
-                self.args_recv_info[chunk],
-                self.kwargs_recv_info[chunk],
-            ) = self._create_act_recv_buffers()
+            self.args_recv_info[chunk] = self._create_act_recv_buffers()
 
         # Send info during forward for each activation
         self.act_send_info = self._create_act_send_info()
@@ -211,10 +206,9 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
             # Send info for input grads during backward
             # List of destinations corresponding to input grads
             # Can be None if an input has no grad
-            # `grad_send_info` is a mirror of `args_recv_info` + `kwargs_recv_info`
+            # `grad_send_info` is a mirror of `args_recv_info`
             self.grad_send_info = self._create_grad_send_info(
-                self.args_recv_info[0],
-                self.kwargs_recv_info[0],
+                self.args_recv_info[0]
             )
 
     def get_stage_index_of_submod(
@@ -283,15 +277,11 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
         # Tuple[RecvInfo]
         args_recv_info = map_arg(self.node.args, create_recv_tensor)
 
-        # `kwargs` is a Dict, hence we will have:
-        # Dict[keyword, RecvInfo]
-        kwargs_recv_info = map_arg(self.node.kwargs, create_recv_tensor)
-
         logger.info(
             f"[{self.group_rank}] "
             f"Activation recv / args info: {args_recv_info}"
         )
-        return args_recv_info, kwargs_recv_info
+        return args_recv_info
 
     def find_dst_rank(
         self,
@@ -371,7 +361,6 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
     def _create_grad_send_info(
         self,
         args_recv_info: Tuple,
-        kwargs_recv_info: Dict,
     ) -> List[Optional[int]]:
         grad_send_info: List[Optional[int]] = []
 
@@ -384,8 +373,6 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
                 return None
 
         map_aggregate(args_recv_info, map_recv_to_send)
-
-        map_aggregate(kwargs_recv_info, map_recv_to_send)
 
         logger.info(f"[{self.group_rank}] " f"Grad send info: {grad_send_info}")
         return grad_send_info
@@ -415,8 +402,8 @@ class PipelineStage(torch.nn.Module, QualnameMapMixin):
         return lambda info: self._recv_tensor(info, reqs)
 
     def split_inputs(self, args, kwargs):
-        self.args_split = None
-        self.kwargs_split = None
+        self.args_split = []
+        self.kwargs_split = []
         if args or kwargs:
             self.args_split, self.kwargs_split = split_args_kwargs_into_chunks(
                 args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #964
* #963
* #962
* #961
* #960
* __->__ #959

A series of PRs to simplify `PipelineStage` class then migrate to `PipelineSchedule`