### PR TITLE
Allow step to take no microbatch (e.g. middle stages)

### DIFF
--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -432,30 +432,28 @@ class PipelineStageV2Impl(PipelineStageBase):
     def forward_one_chunk(
         self, args: Union[torch.Tensor, List[torch.tensor]]
     ) -> Any:
-        if self.is_first_stage:
-            # we always expect to unpack an iterable of inputs, so if its a single tensor, wrap it in a list
-            if isinstance(args, torch.Tensor):
-                args = [args]
-            self.inputs = args
+        # we always expect to unpack a tuple of inputs, so if its a single tensor, wrap it in a tuple
+        if isinstance(args, torch.Tensor):
+            args = (args,)
 
         logger.info(
-            f"[{self.rank} FORWARD {self.stage_id} {[inp.shape for inp in self.inputs]}"
+            f"[{self.rank} FORWARD {self.stage_id} {[inp.shape for inp in args]}"
         )
 
         # this is needed when we access the gradients for this in backward()
         # TODO: requires_grad should not be set, it should depend on input (https://github.com/pytorch/PiPPy/issues/945)
-        for tensor in self.inputs:
+        for tensor in args:
             tensor.requires_grad = True
             tensor.retain_grad()
 
         # perform forward pass on module
-        outputs = self.module(*self.inputs)
+        outputs = self.module(*args)
         self.outputs = self.check_and_format_outputs(outputs)
 
         outputs_or_loss = self.compute_loss() if self.is_last_stage else outputs
 
         # we store a ref to the input/output pair for this forward to be later used by the corresponding backward
-        self.inputs_outputs.append((self.inputs, outputs_or_loss))
+        self.inputs_outputs.append((args, outputs_or_loss))
 
         return outputs_or_loss
 
@@ -517,8 +515,12 @@ class PipelineStageV2Impl(PipelineStageBase):
 
 
 class PipelineSchedule(ABC):
+    def __init__(self, stage: PipelineStageBase, n_microbatches: int):
+        self._stage = stage
+        self._n_microbatches = n_microbatches
+
     @abstractmethod
-    def step(self, microbatches: List[torch.Tensor]) -> None:
+    def step(self, microbatches: Optional[List]=None) -> None:
         """
         Run one iteration of the pipeline schedule. Will go through all the microbatches
         according to the schedule implementation.
@@ -530,17 +532,20 @@ class PipelineSchedule(ABC):
 
 
 class PipelineScheduleGPipe(PipelineSchedule):
-    def __init__(self, stage: PipelineStageBase):
-        self._stage = stage
+    def step(self, microbatches: Optional[List]=None):
+        if microbatches is not None:
+            assert len(microbatches) == self._n_microbatches
 
-    def step(self, microbatches):
-        for i, mb in enumerate(microbatches):
+        for i in range(self._n_microbatches):
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops()
                 if ops:
                     dist.batch_isend_irecv(ops).pop().wait()
 
-                self._stage.forward_one_chunk(mb)
+                if microbatches is not None:
+                    self._stage.forward_one_chunk(microbatches[i])
+                else:
+                    self._stage.forward_one_chunk(self.inputs)
 
                 ops = self._stage.get_fwd_send_ops()
                 if ops:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #967
* #966
* __->__ #964
* #963
* #962
* #961
* #960
* #959

Middle stages should be able to simply call:
`schedule.step()`
instead of 
`schedule.step(mb)`
because they don't have microbatch inputs.