### PR TITLE
add pipeline schedule unittests to CI

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov numpy datasets evaluate scikit-learn sacrebleu
+          pip install flake8 pytest pytest-cov numpy datasets evaluate scikit-learn sacrebleu expecttest
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Install pippy
         run: "python setup.py install"
@@ -102,6 +102,8 @@ jobs:
         run: torchrun --nproc-per-node 3 examples/basic/example.py
       - name: Run auto-split test
         run: torchrun --nproc-per-node 4 test/test_autosplit.py
+      - name: Test pipeline schedule
+        run: python test/test_pipeline_schedule.py
       # - name: Run null_coalesce_accumulate integration test
       #   run: python test/local_test_null_coalesce_accumulate.py --replicate ${{ matrix.replicate }} --schedule ${{ matrix.schedule }}
       # - name: Run PP + DDP test

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -183,7 +183,7 @@ def get_stage_shapes(
     """
 
     stage_id_to_shapes: Dict[int, Dict[str, torch.Size]] = {}
-    for stage_id, model in zip(stage_ids, models, strict=True):
+    for stage_id, model in zip(stage_ids, models):
         input_shape_metadata_tensor = create_metadata_tensor(device=device)
         # TODO: Assumes prev_stage == rank - 1 and next_stage == rank + 1
         prev_rank = (rank - 1) % world_size


### PR DESCRIPTION
Needed to add `expecttest` as a dependency since `torch.testing._internal.common_distributed` imports it

removed `strict=True` from zip since that is only supported for python 3.10+ and tests (and pytorch) should support 3.9