### PR TITLE
Sort batch_isend_irecv to support skip connections

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -55,6 +55,8 @@ jobs:
         run: torchrun --nproc-per-node 4 test/test_bwd.py
       - name: Run optimizer test
         run: torchrun --nproc-per-node 4 test/test_optim.py
+      - name: Test skip connection support
+        run: torchrun --nproc-per-node 4 test/test_skip_conn.py
       - name: Run example
         run: torchrun --nproc-per-node 3 examples/basic/example.py
       - name: Run training example

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -2,7 +2,8 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional
+from collections import defaultdict
+from typing import Callable, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
@@ -63,6 +64,31 @@ class PipelineSchedule(ABC):
         raise NotImplementedError
 
 
+def sorted_batch_isend_irecv(p2p_ops: List[dist.P2POp]) -> Dict[int, dist.Work]:
+    """
+    Sorts the list of P2P ops by the peer rank, and then calls
+    batch_isend_irecv. Return a dictionary of works by peer rank. This function
+    helps us avoid hangs in case of skip connections.
+    """
+    # Arrange p2p_ops by peer rank:
+    #   int is the peer rank;
+    #   List is the list of ops towards the peer
+    ops_by_peer: Dict[int, List[dist.P2POp]] = defaultdict(list)
+    work_by_peer: Dict[int, dist.Work] = {}
+    if len(p2p_ops) == 0:
+        return work_by_peer
+
+    # Classify the ops by peer rank
+    for op in p2p_ops:
+        ops_by_peer[op.peer].append(op)
+
+    # Call batch_isend_irecv per peer, in sorted order of the peers (to avoid hangs)
+    for peer, ops in sorted(ops_by_peer.items()):
+        work_by_peer[peer] = dist.batch_isend_irecv(ops).pop()
+
+    return work_by_peer
+
+
 class PipelineScheduleGPipe(PipelineSchedule):
     def step_microbatches(
         self,
@@ -99,14 +125,15 @@ class PipelineScheduleGPipe(PipelineSchedule):
         for i in range(self._n_microbatches):
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops()
-                if ops:
-                    dist.batch_isend_irecv(ops).pop().wait()
+                works = sorted_batch_isend_irecv(ops)
+                for work in works.values():
+                    work.wait()
 
                 output = self._stage.forward_one_chunk(arg_mbs[i], kwarg_mbs[i])
 
                 ops = self._stage.get_fwd_send_ops()
-                if ops:
-                    dist.batch_isend_irecv(ops)
+                works = sorted_batch_isend_irecv(ops)
+                # TODO: check if we need to wait for works, i.e. check if there is risk of overwrite
 
             logger.debug(
                 f"[{self._stage.stage_index}] Forwarded microbatch {i}"
@@ -131,15 +158,16 @@ class PipelineScheduleGPipe(PipelineSchedule):
         for i in range(self._n_microbatches):
             with record_function(f"Backward {i}"):
                 ops = self._stage.get_bwd_recv_ops()
-                if ops:
-                    dist.batch_isend_irecv(ops).pop().wait()
+                works = sorted_batch_isend_irecv(ops)
+                for work in works.values():
+                    work.wait()
 
                 loss = internal_losses[i] if len(internal_losses) > 0 else None
                 self._stage.backward_one_chunk(loss=loss)
 
                 ops = self._stage.get_bwd_send_ops()
-                if ops:
-                    dist.batch_isend_irecv(ops)
+                works = sorted_batch_isend_irecv(ops)
+                # TODO: check if we need to wait for works, i.e. check if there is risk of overwrite
 
             logger.debug(
                 f"[{self._stage.stage_index}] Backwarded microbatch {i}"

--- a/test/test_skip_conn.py
+++ b/test/test_skip_conn.py
@@ -1,0 +1,141 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import argparse
+import os
+import unittest
+
+import pippy
+
+import torch
+import torch.distributed as dist
+from pippy.IR import pipe_split, pipeline
+from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineStage import PipelineStage
+
+
+pippy.microbatch._debug_mask_minibatches = True
+
+d_hid = 512
+batch_size = 256
+
+torch.manual_seed(0)
+
+
+class ExampleCode(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x, y=torch.zeros(batch_size, d_hid)):
+        x = torch.mm(x, self.mm_param)
+        x = x + y
+        x = torch.relu(x)
+        skip_conn = x
+        pipe_split()
+        x = torch.mm(x, self.mm_param)
+        x = self.lin(x)
+        pipe_split()
+        x = torch.relu(x)
+        x = torch.mm(x, self.mm_param2)
+        pipe_split()
+        x = x + skip_conn
+        x = self.lin(x)
+        x = torch.relu(x)
+        return x
+
+
+def run_worker(args):
+    mod = ExampleCode()
+    mod.to(args.device)
+
+    x = torch.randn(batch_size, d_hid, device=args.device)
+    y = torch.randn(batch_size, d_hid, device=args.device)
+
+    pipe = pipeline(
+        mod,
+        args.chunks,
+        example_args=(x,),
+        example_kwargs={"y": y},
+    )
+
+    stage = PipelineStage(
+        pipe,
+        args.rank,
+        device=args.device,
+    )
+
+    # Attach to a schedule
+    schedule = PipelineScheduleGPipe(stage, args.chunks)
+
+    # Run
+    if args.rank == 0:
+        schedule.step(x, y=y)
+    else:
+        out = schedule.step()
+
+    dist.barrier()
+    print(f"Rank {args.rank} completes")
+
+    # Last rank checks result
+    if args.rank == args.world_size - 1:
+        ref_out = mod(x, y=y)
+        torch.testing.assert_close(out, ref_out)
+        print(
+            f"equivalence test passed {torch.sum(out)} ref {torch.sum(ref_out)}"
+        )
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size", type=int, default=int(os.getenv("WORLD_SIZE", 4))
+    )
+    parser.add_argument("--rank", type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument(
+        "--master_addr", type=str, default=os.getenv("MASTER_ADDR", "localhost")
+    )
+    parser.add_argument(
+        "--master_port", type=str, default=os.getenv("MASTER_PORT", "29500")
+    )
+    parser.add_argument(
+        "--cuda", type=int, default=int(torch.cuda.is_available())
+    )
+    parser.add_argument(
+        "--chunks",
+        type=int,
+        default=4,
+    )
+    args = parser.parse_args(args)
+
+    if args.cuda:
+        dev_id = args.rank % torch.cuda.device_count()
+        args.device = torch.device(f"cuda:{dev_id}")
+    else:
+        args.device = torch.device("cpu")
+
+    # Init process group
+    backend = "nccl" if args.cuda else "gloo"
+    dist.init_process_group(
+        backend=backend,
+        rank=args.rank,
+        world_size=args.world_size,
+    )
+
+    run_worker(args)
+
+
+if __name__ == "__main__":
+    main()
+
+
+class TestSkipConn(unittest.TestCase):
+    def test_skip_conn(self):
+        import random
+
+        port = random.randint(29500, 30000)
+        args = [
+            "--master_port",
+            str(port),
+        ]
+        main(args)


### PR DESCRIPTION
As described in #969 , if we batch across peers for P2P comms, batch_isend_irecv can hang when skip connection is present.

This PR classifies the P2P ops by peer rank, and calls batch_isend_irecv **per peer** for the group of ops towards that peer, instead of a single, big batch_isend_irecv.

Covered schedules:
- GPipe
- 1F1B

Not covered:
- Interleaved 1F1B (TODO)