### PR TITLE
Add loss and step support to 1F1B

### DIFF
--- a/.github/workflows/gpu_tests.yaml
+++ b/.github/workflows/gpu_tests.yaml
@@ -24,7 +24,7 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 jobs:
-  unit_tests_4gpu:
+  forward_tests_4gpu:
     runs-on: linux.g5.12xlarge.nvidia.gpu
     strategy:
       matrix:
@@ -51,10 +51,6 @@ jobs:
         run: torchrun --nproc-per-node 4 test/test_fwd.py
       - name: Run auto-split test
         run: torchrun --nproc-per-node 4 test/test_autosplit.py
-      - name: Run forward-backward test
-        run: torchrun --nproc-per-node 4 test/test_bwd.py
-      - name: Run optimizer test
-        run: torchrun --nproc-per-node 4 test/test_optim.py
       - name: Test skip connection support
         run: torchrun --nproc-per-node 4 test/test_skip_conn.py
       - name: Run example
@@ -69,3 +65,33 @@ jobs:
         run: torchrun --nproc-per-node 2 examples/huggingface/pippy_t5.py
       - name: Run BERT
         run: torchrun --nproc-per-node 4 examples/huggingface/pippy_bert.py
+
+jobs:
+  backward_tests_4gpu:
+    runs-on: linux.g5.12xlarge.nvidia.gpu
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        schedule: ["gpipe", "1f1b"]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+      - name: Activate conda env
+        run: conda activate test
+      - name: Install dependencies
+        run:
+          pip install numpy
+          pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cu121
+      - name: Install pippy
+        run: python setup.py install
+      - name: Run forward-backward test
+        run: torchrun --nproc-per-node 4 test/test_bwd.py --schedule ${{ matrix.schedule }}
+      - name: Run optimizer test
+        run: torchrun --nproc-per-node 4 test/test_optim.py --schedule ${{ matrix.schedule }}

--- a/test/test_bwd.py
+++ b/test/test_bwd.py
@@ -7,14 +7,14 @@ import torch
 import torch.distributed as dist
 
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import PipelineSchedule1F1B, PipelineScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
-schedules = [
-    "FillDrain",
-    "1F1B",
-]
+schedule_map = {
+    "gpipe": PipelineScheduleGPipe,
+    "1f1b": PipelineSchedule1F1B,
+}
 
 d_hid = 512
 batch_size = 256
@@ -66,7 +66,9 @@ def run_worker(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks, loss_fn=loss_fn)
+    ScheduleClass = schedule_map[args.schedule]
+    print(f"Using {ScheduleClass.__name__}")
+    schedule = ScheduleClass(stage, args.chunks, loss_fn=loss_fn)
 
     # Run
     if args.rank == 0:
@@ -112,8 +114,8 @@ def main(args=None):
     parser.add_argument(
         "--schedule",
         type=str,
-        default="FillDrain",
-        choices=schedules,
+        default="gpipe",
+        choices=schedule_map.keys(),
     )
     args = parser.parse_args(args)
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -11,9 +11,14 @@ import torch.distributed as dist
 import torch.optim as optim
 
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import PipelineSchedule1F1B, PipelineScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
+
+schedule_map = {
+    "gpipe": PipelineScheduleGPipe,
+    "1f1b": PipelineSchedule1F1B,
+}
 
 d_hid = 512
 batch_size = 256
@@ -65,7 +70,9 @@ def run_worker(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks, loss_fn=loss_fn)
+    ScheduleClass = schedule_map[args.schedule]
+    print(f"Using {ScheduleClass.__name__}")
+    schedule = ScheduleClass(stage, args.chunks, loss_fn=loss_fn)
 
     # Create an optimizer for stage submodule's parameters
     optimizer = optim.SGD(stage.submod.parameters(), lr=1e-3, momentum=0.9)
@@ -109,6 +116,12 @@ def main(args=None):
         "--chunks",
         type=int,
         default=4,
+    )
+    parser.add_argument(
+        "--schedule",
+        type=str,
+        default="gpipe",
+        choices=schedule_map.keys(),
     )
     args = parser.parse_args(args)
 


### PR DESCRIPTION
- Add loss and step to 1F1B
- Extend backward tests to support different schedules
- Iterate over schedules in CI

```
$torchrun --nproc-per-node 4 test/test_bwd.py --schedule 1f1b
```
```
Using PipelineSchedule1F1B
Using PipelineSchedule1F1B
Using PipelineSchedule1F1B
Using PipelineSchedule1F1B
NCCL version 2.20.5+cuda12.4
Rank 3 completes
Rank 2 completes
Rank 1 completes
Rank 0 completes
```