### PR TITLE
Remove qualname remap support

### DIFF
--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -15,7 +15,7 @@ from pippy.backward import stage_backward
 from pippy.debug import map_debug_info
 from pippy.IR import Pipe
 from pippy.microbatch import merge_chunks, split_args_kwargs_into_chunks
-from pippy.utils import flatten_args, modify_graph_op_device, QualnameMapMixin
+from pippy.utils import flatten_args, modify_graph_op_device
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,7 @@ class RootArgPlaceholder:
 InputInfo = Union[RecvInfo, RootArgPlaceholder]
 
 
-class PipelineStage(PipelineStageBase, QualnameMapMixin):
+class PipelineStage(PipelineStageBase):
     def __init__(
         self,
         pipe: Pipe,
@@ -206,13 +206,6 @@ class PipelineStage(PipelineStageBase, QualnameMapMixin):
         logger.info(
             f"[{self.group_rank}] "
             f"Creating PipelineStage {stage_index} for {self.name}"
-        )
-
-        # Enable `remap_qualname` method
-        QualnameMapMixin.__init__(
-            self,
-            pipe.submod_qualname_mappings[self.name],
-            pipe.tracer_qualname_map,
         )
 
         # Find my forward node in graph

--- a/test/test_fwd.py
+++ b/test/test_fwd.py
@@ -86,13 +86,11 @@ def run_worker(args):
         )
 
     # Test qualname mapping
-    sd = stage.submod.state_dict()
-    print(f"Rank {args.rank} state dict keys: {sd.keys()}")
-    remapped_keys = [stage.remap_qualname(k) for k in sd.keys()]
-    print(f"Rank {args.rank} remapped keys: {remapped_keys}")
-    # Confirm remapped keys are consistent with original model
+    submod_keys = stage.submod.state_dict().keys()
+    print(f"Rank {args.rank} state dict keys: {submod_keys}")
+    # Confirm keys are consistent with original model
     old_keys = mod.state_dict().keys()
-    assert all(rk in old_keys for rk in remapped_keys)
+    assert all(k in old_keys for k in submod_keys)
     print(f"Qualname test passed")
 
 


### PR DESCRIPTION
Because unflattening already made the FQNs the same as the original FQNs.

Also modified test to directly assert FQN equivalence.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1030
* __->__ #1023

