### PR TITLE
Unify pipeline stages fwd and bwd, add pipeline stage tests

### DIFF
--- a/pippy/ManualPipelineStage.py
+++ b/pippy/ManualPipelineStage.py
@@ -8,6 +8,12 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from pippy.microbatch import (
+    merge_chunks,
+    split_args_kwargs_into_chunks,
+    TensorChunkSpec,
+)
+
 from pippy.PipelineStage import PipelineStageBase
 
 logger = logging.getLogger(__name__)
@@ -166,107 +172,6 @@ def get_stage_shapes(
     return stage_id_to_shapes
 
 
-def validate_stage_shapes(pipeline_stages: List[PipelineStageBase]):
-    """
-    Check that the buffer shapes match between stages was expected by performing an all_gather between
-    all stages. Assumes that buffers have been initialized already such that get_fwd_recv_ops() and
-    get_fwd_send_ops() return valid lists of p2p ops.
-    """
-    if len(pipeline_stages) == 0:
-        raise ValueError("No pipeline stages provided.")
-
-    virtual_pipeline_size = len(pipeline_stages)
-    all_inputs = []
-    all_outputs = []
-    world_size = pipeline_stages[0].world_size
-    num_stages = pipeline_stages[0].num_stages
-
-    # perform all gathers between all stages
-    for virtual_id, stage in enumerate(pipeline_stages):
-        world_size = stage.world_size
-        stage_id = stage.stage_index
-        rank = stage.rank
-        # check that world_size and num_stages are consistent across all stages
-        if stage.world_size != world_size:
-            raise ValueError(
-                f"Stage id {stage_id} has world size ({stage.world_size}) which does not match world size ({world_size}) of other stages."
-            )
-        if stage.num_stages != num_stages:
-            raise ValueError(
-                f"Stage id {stage_id} has num stages ({stage.num_stages}) which does not match num stages ({num_stages}) of other stages."
-            )
-
-        # TODO: once we pass in pg to stage, check the pg rank is same as stage rank
-        if rank != (pg_rank := dist.get_rank()):
-            raise ValueError(
-                f"Rank {rank} is not equal to process group rank {pg_rank}"
-            )
-
-        if (num_stages := stage.num_stages) % world_size != 0:
-            raise ValueError(
-                f"Number of stages ({num_stages}) must be a multiple of the world_size ({world_size})"
-            )
-
-        # all gather each ranks inputs
-        tensor_list = [
-            create_metadata_tensor(device=stage.device)
-            for _ in range(stage.world_size)
-        ]
-        expected_inputs = [op.tensor for op in stage.get_fwd_recv_ops()]
-        stage_input = create_metadata_tensor(
-            expected_inputs, device=stage.device
-        )
-        dist.all_gather(tensor_list, stage_input)
-        stage_input_shapes = [
-            extract_metadata_from_tensor(tensor) for tensor in tensor_list
-        ]
-
-        # all gather each ranks outputs
-        tensor_list = [
-            create_metadata_tensor(device=stage.device)
-            for _ in range(stage.world_size)
-        ]
-        expected_outputs = [op.tensor for op in stage.get_fwd_send_ops()]
-        stage_output = create_metadata_tensor(
-            expected_outputs, device=stage.device
-        )
-        dist.all_gather(tensor_list, stage_output)
-        stage_output_shapes = [
-            extract_metadata_from_tensor(tensor) for tensor in tensor_list
-        ]
-
-        logger.debug(
-            f"""
-            Rank: {pg_rank}
-            Stage id: {stage_id}
-            Stage num stages: {stage.num_stages}
-            Stage rank: {rank}
-            Stage world size: {world_size}
-            Stage {virtual_id * world_size}-{(virtual_id + 1) * world_size - 1} input shapes: {stage_input_shapes}
-            Stage {virtual_id * world_size}-{(virtual_id + 1) * world_size - 1} output shapes: {stage_output_shapes}
-        """
-        )
-
-        all_inputs.extend(stage_input_shapes)
-        all_outputs.extend(stage_output_shapes)
-
-    # log only rank 0's view, they will all be equivalent
-    if pg_rank == 0:
-        logger.info(
-            f"""
-            all stage inputs: {all_inputs}
-            all stage outputs: {all_outputs}
-        """
-        )
-
-    # Check if the output for stage 0 matches the input at stage 1, and so forth
-    for i in range(virtual_pipeline_size * world_size - 1):
-        if (out := all_outputs[i]) != (inp := all_inputs[i + 1]):
-            raise ValueError(
-                f"Stage_id {stage_id} output shape {out} at does not match stage_id {i + 1} input shape {inp}."
-            )
-
-
 class ManualPipelineStage(PipelineStageBase):
     def __init__(
         self,
@@ -274,11 +179,14 @@ class ManualPipelineStage(PipelineStageBase):
         stage_id: int,
         num_stages: int,
         device: torch.device,
+        num_microbatches: int,
         group: dist.ProcessGroup = None,
         input_args: Optional[Union[torch.Tensor, List[torch.tensor]]] = None,
         output_args: Optional[Union[torch.Tensor, List[torch.tensor]]] = None,
     ):
-        super().__init__(stage_id, num_stages, device, group)
+        super().__init__(
+            module, stage_id, num_stages, device, num_microbatches, group
+        )
         self.module = module.to(device)
         self.is_first_stage = stage_id == 0
         self.is_last_stage = stage_id == num_stages - 1
@@ -302,7 +210,6 @@ class ManualPipelineStage(PipelineStageBase):
         self.inputs_outputs: Deque[Tuple[Tuple[Any, ...], Any]] = deque()
 
         # these are the buffers used in backwards send/recv, they are allocated later
-        self.inputs_grad: List[torch.tensor] = []
         self.outputs_grad: List[torch.tensor] = []
 
         def stage_global_rank(peer_rank):
@@ -323,6 +230,61 @@ class ManualPipelineStage(PipelineStageBase):
             output: {[output.shape for output in self.outputs]}
             """
         )
+
+    def _retrieve_recv_activations(
+        self,
+    ):
+        """
+        Retrieve the activations received for the current stage during forward.
+        """
+        # TODO: grad always gets set but later
+        # we can selectively choose which inputs require grads
+        for inp in self.inputs:
+            inp.requires_grad_(True)
+        return self.inputs
+
+    def _retrieve_recv_grads(
+        self,
+    ):
+        """
+        Retrieve the gradients received for the current stage during backward.
+        """
+        # TODO fix so we dont create a tensor
+        self.outputs_grad = [torch.empty_like(x) for x in self.outputs]
+        return self.outputs_grad
+
+    def split_inputs(
+        self,
+        args: Tuple[Any, ...],
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Splits a full-batch input into chunks (i.e. microbatches) and returns
+        the chunks
+        """
+        if args or kwargs:
+            # TODO: cannot split on another dimension other than 0
+            args_split, kwargs_split = split_args_kwargs_into_chunks(
+                args,
+                kwargs,
+                self.chunks,
+            )
+            return args_split, kwargs_split
+        else:
+            # Empty inputs (e.g. when called on middle stages)
+            # Return a list of empty tuples/dicts with matching length as chunks
+            return [()] * self.chunks, [{}] * self.chunks
+
+    def merge_outputs(self):
+        # TODO: manual stage only supports splitting on dimension 0
+        # Last rank return merged results per original format
+        if self.is_last:
+            return merge_chunks(
+                self.output_chunks,
+                TensorChunkSpec(0),
+            )
+        else:
+            return None
 
     def init_p2p_neighbors(self):
         """
@@ -365,14 +327,14 @@ class ManualPipelineStage(PipelineStageBase):
         ]
 
     def get_fwd_send_ops(self) -> List[dist.P2POp]:
-        assert (
-            len(self.outputs) != 0
-        ), "forward() must be called before get_fwd_send_ops"
+        output_tuples, flatten_input_tensors = self.fwd_cache[
+            self.fwd_chunk_id - 1
+        ]
         if self.is_last_stage:
             return []
         return [
             dist.P2POp(dist.isend, out, self.next_stage, self.group)
-            for out in self.outputs
+            for out in output_tuples
         ]
         raise AssertionError("invalid fwd_outputs type, cannot send")
 
@@ -393,48 +355,9 @@ class ManualPipelineStage(PipelineStageBase):
             )
         return outputs
 
-    def forward_one_chunk(
-        self,
-        args: Tuple[Any, ...],
-        kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Any:
-        # Non-0 stage
-        if args is None:
-            args = self.inputs
-
-        # we always expect to unpack a tuple of inputs, so if its a single tensor, wrap it in a tuple
-        if isinstance(args, torch.Tensor):
-            args = (args,)
-
-        logger.info(
-            f"[{self.rank} FORWARD {self.stage_index} {[inp.shape for inp in args]}"
-        )
-
-        # this is needed when we access the gradients for this in backward()
-        # TODO: requires_grad should not be set, it should depend on input (https://github.com/pytorch/PiPPy/issues/945)
-        for tensor in args:
-            tensor.requires_grad = True
-            tensor.retain_grad()
-
-        # perform forward pass on module
-        outputs = self.module(*args)
-        self.outputs = self.check_and_format_outputs(outputs)
-
-        # TODO: this is a hack to get the loss, we should be able to get the
-        # loss with the loss_fn in PipelineSchedule
-        # outputs_or_loss = self.compute_loss() if self.is_last_stage else outputs
-        outputs_or_loss = outputs
-
-        # we store a ref to the input/output pair for this forward to be later used by the corresponding backward
-        self.inputs_outputs.append((args, outputs_or_loss))
-
-        return outputs_or_loss
-
     def get_bwd_recv_ops(self) -> List[dist.P2POp]:
         if self.is_last_stage:
             return []
-        # grads should be same shape as the output from forward()
-        self.outputs_grad = [torch.empty_like(out) for out in self.outputs]
         return [
             dist.P2POp(dist.irecv, grad, self.next_stage, self.group)
             for grad in self.outputs_grad
@@ -444,39 +367,106 @@ class ManualPipelineStage(PipelineStageBase):
         if self.is_first_stage:
             return []
         return [
-            dist.P2POp(dist.isend, grad, self.prev_stage, self.group)
-            for grad in self.inputs_grad
+            dist.P2POp(dist.isend, inp.grad, self.prev_stage, self.group)
+            for inp in self.inputs
         ]
 
-    def backward_one_chunk(self, **kwargs) -> None:
-        logger.info(f"[{self.rank} BACKWARD {self.stage_index}]")
 
-        if self.is_last_stage:
-            inputs, loss = self.inputs_outputs.popleft()
-        else:
-            inputs, outputs = self.inputs_outputs.popleft()
+def validate_stage_shapes(pipeline_stages: List[ManualPipelineStage]):
+    """
+    Check that the buffer shapes match between stages was expected by performing an all_gather between
+    all stages.
+    """
+    if len(pipeline_stages) == 0:
+        raise ValueError("No pipeline stages provided.")
 
-        # Compute gradients
-        # TODO: HACK materialize_grads=True sets gradients to 0s on backward pass,
-        # we need set all the gradients for the inputs that need it, but should not send 0s
-        # due to extra communication
-        # TODO: torch.autograd.grad won't accumulate grad for model parameters.
-        if self.is_last_stage:
-            gradients = torch.autograd.grad(
-                outputs=loss,
-                inputs=inputs,
-                retain_graph=True,
-                allow_unused=True,
-                materialize_grads=True,
+    virtual_pipeline_size = len(pipeline_stages)
+    all_inputs = []
+    all_outputs = []
+    world_size = pipeline_stages[0].world_size
+    num_stages = pipeline_stages[0].num_stages
+
+    # perform all gathers between all stages
+    for virtual_id, stage in enumerate(pipeline_stages):
+        world_size = stage.world_size
+        stage_id = stage.stage_index
+        rank = stage.rank
+        # check that world_size and num_stages are consistent across all stages
+        if stage.world_size != world_size:
+            raise ValueError(
+                f"Stage id {stage_id} has world size ({stage.world_size}) which does not match world size ({world_size}) of other stages."
             )
-        else:
-            gradients = torch.autograd.grad(
-                outputs=outputs,
-                inputs=inputs,
-                grad_outputs=self.outputs_grad,
-                retain_graph=True,
-                allow_unused=True,
-                materialize_grads=True,
+        if stage.num_stages != num_stages:
+            raise ValueError(
+                f"Stage id {stage_id} has num stages ({stage.num_stages}) which does not match num stages ({num_stages}) of other stages."
             )
 
-        self.inputs_grad = gradients
+        # TODO: once we pass in pg to stage, check the pg rank is same as stage rank
+        if rank != (pg_rank := dist.get_rank()):
+            raise ValueError(
+                f"Rank {rank} is not equal to process group rank {pg_rank}"
+            )
+
+        if (num_stages := stage.num_stages) % world_size != 0:
+            raise ValueError(
+                f"Number of stages ({num_stages}) must be a multiple of the world_size ({world_size})"
+            )
+
+        # all gather each ranks inputs
+        tensor_list = [
+            create_metadata_tensor(device=stage.device)
+            for _ in range(stage.world_size)
+        ]
+        expected_inputs = stage.inputs
+        stage_input = create_metadata_tensor(
+            expected_inputs, device=stage.device
+        )
+        dist.all_gather(tensor_list, stage_input)
+        stage_input_shapes = [
+            extract_metadata_from_tensor(tensor) for tensor in tensor_list
+        ]
+
+        # all gather each ranks outputs
+        tensor_list = [
+            create_metadata_tensor(device=stage.device)
+            for _ in range(stage.world_size)
+        ]
+        expected_outputs = stage.outputs
+        stage_output = create_metadata_tensor(
+            expected_outputs, device=stage.device
+        )
+        dist.all_gather(tensor_list, stage_output)
+        stage_output_shapes = [
+            extract_metadata_from_tensor(tensor) for tensor in tensor_list
+        ]
+
+        logger.debug(
+            f"""
+            Rank: {pg_rank}
+            Stage id: {stage_id}
+            Stage num stages: {stage.num_stages}
+            Stage rank: {rank}
+            Stage world size: {world_size}
+            Stage {virtual_id * world_size}-{(virtual_id + 1) * world_size - 1} input shapes: {stage_input_shapes}
+            Stage {virtual_id * world_size}-{(virtual_id + 1) * world_size - 1} output shapes: {stage_output_shapes}
+        """
+        )
+
+        all_inputs.extend(stage_input_shapes)
+        all_outputs.extend(stage_output_shapes)
+
+    # log only rank 0's view, they will all be equivalent
+    if pg_rank == 0:
+        logger.info(
+            f"""
+            all stage inputs: {all_inputs}
+            all stage outputs: {all_outputs}
+        """
+        )
+
+    # Check if the output for stage 0 matches the input at stage 1, and so forth
+    for i in range(virtual_pipeline_size * world_size - 1):
+        if (out := all_outputs[i]) != (inp := all_inputs[i + 1]):
+            raise ValueError(
+                f"Stage_id {stage_id} output shape {out} at does not match stage_id {i + 1} input shape {inp}."
+            )

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -401,7 +401,7 @@ class PipelineScheduleLoopedBFS(PipelineSchedule):
                     if ops:
                         dist.batch_isend_irecv(ops).pop().wait()
 
-                    stage.backward_one_chunk(chunk=i)
+                    stage.backward_one_chunk()
 
                     ops = stage.get_bwd_send_ops()
                     if ops:

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -23,10 +23,12 @@ logger = logging.getLogger(__name__)
 class PipelineStageBase(ABC):
     def __init__(
         self,
+        submodule: torch.nn.Module,
         stage_index: int,
         num_stages: int,
         device: torch.device,
-        group: dist.ProcessGroup = None,
+        num_microbatches: int,
+        group: Optional[dist.ProcessGroup] = None,
     ):
         super().__init__()
         if stage_index >= num_stages:
@@ -34,10 +36,25 @@ class PipelineStageBase(ABC):
                 f"Stage index {stage_index} is out of range of {num_stages}"
             )
 
+        self.submod = submodule
         self.stage_index = stage_index
         self.num_stages = num_stages
         self.device = device
+        self.chunks = num_microbatches
         self.group = group
+
+        # `group_rank` is rank in process group `group`.
+        self.group_rank = dist.get_rank(group)
+
+        # Run time states
+        # map microbatch ID to list of forward tensor args
+        self.fwd_cache: Dict[int, Tuple[Any, List[torch.Tensor]]] = {}
+        # Current forward chunk id
+        self.fwd_chunk_id: int = 0
+        # Current backward chunk id
+        self.bwd_chunk_id: int = 0
+        # Caching chunk outputs for final output merge or reduction
+        self.output_chunks: List[Any] = []
 
         # TODO: rename `rank` to `group_rank`
         self.rank = dist.get_rank(self.group)
@@ -70,17 +87,6 @@ class PipelineStageBase(ABC):
         return self.stage_index == self.num_stages - 1
 
     @abstractmethod
-    def forward_one_chunk(self, *args, **kwargs):
-        """
-        Perform forward pass on the module.
-        This should only be called once per microbatch.
-
-        Args:
-            microbatch: The input to the module
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def get_fwd_recv_ops(self) -> List[dist.P2POp]:
         """
         Get the list of P2P operations that need to be performed before calling forward()
@@ -91,14 +97,6 @@ class PipelineStageBase(ABC):
     def get_fwd_send_ops(self) -> List[dist.P2POp]:
         """
         Get the list of P2P operations that need to be performed after calling forward()
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def backward_one_chunk(self, **kwargs):
-        """
-        Perform backward pass on the module.
-        This should only be called once per microbatch.
         """
         raise NotImplementedError
 
@@ -120,7 +118,13 @@ class PipelineStageBase(ABC):
         """
         Clear runtime states of the stage.
         """
-        raise NotImplementedError
+        # Reset pointers
+        self.fwd_chunk_id = 0
+        self.bwd_chunk_id = 0
+        # map microbatch ID to list of forward tensor args
+        self.fwd_cache.clear()
+        # Caching chunk outputs for final output merge or reduction
+        self.output_chunks.clear()
 
     def split_inputs(
         self,
@@ -140,6 +144,151 @@ class PipelineStageBase(ABC):
         """
         # TODO: lift an implementation here from PipelineStage or move it to PipelineSchedule
         raise NotImplementedError
+
+    def _retrieve_recv_activations(
+        self,
+    ):
+        """
+        Retrieve the activations received for the current stage during forward.
+        """
+        raise NotImplementedError
+
+    def _retrieve_recv_grads(
+        self,
+    ):
+        """
+        Retrieve the gradients received for the current stage during backward.
+        """
+        raise NotImplementedError
+
+    def forward_maybe_with_nosync(self, *args, **kwargs):
+        # If submod is wrapped with DDP, we use the `no_sync` context manager to
+        # avoid gradient all-reduce per microbatch
+        if isinstance(self.submod, DistributedDataParallel):
+            with self.submod.no_sync():  # type: ignore[operator]
+                out_val = self.submod(*args, **kwargs)
+        else:
+            out_val = self.submod(*args, **kwargs)
+        return out_val
+
+    def backward_maybe_with_nosync(self, bwd_kwargs: Dict, bwd_chunk_id: int):
+        if isinstance(self.submod, DistributedDataParallel):
+            if bwd_chunk_id == self.chunks - 1:
+                # Last chunk, prepare for gradient reduction
+                # HACK: reaching into DDP implementation details here. Is there a better way?
+                self.submod.reducer.prepare_for_backward(  # type: ignore[union-attr, operator]
+                    list(
+                        torch.nn.parallel.distributed._find_tensors(  # type: ignore[attr-defined]
+                            bwd_kwargs["stage_output"]
+                        )
+                    )
+                )
+                grads_input = stage_backward(**bwd_kwargs)
+            else:
+                with self.submod.no_sync():  # type: ignore[operator]
+                    grads_input = stage_backward(**bwd_kwargs)
+        else:
+            # Non-DDP submodule, regular backward
+            grads_input = stage_backward(**bwd_kwargs)
+
+        return grads_input
+
+    def forward_one_chunk(
+        self,
+        args: Tuple[Any, ...],
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        if self.is_first:
+            # First stage doesn't need to receive anything
+            composite_args = args
+            composite_kwargs = kwargs or {}
+        else:
+            # Receive activations for this chunk
+            # Activations only come in args form
+            composite_args = self._retrieve_recv_activations()
+            composite_kwargs = {}
+
+        # Compute forward
+        try:
+            output = self.forward_maybe_with_nosync(
+                *composite_args, **composite_kwargs
+            )
+
+        except Exception as e:
+            exc_msg = f"""s
+            Rank {self.group_rank} failed to run forward stage
+            args: {map_debug_info(composite_args)}
+            kwargs: {map_debug_info(composite_kwargs)}
+            """
+            raise RuntimeError(exc_msg) from e
+
+        if type(output) is list:
+            # HACK: this is a hacky workaround for the fact that export creates
+            # output in list format
+            output = tuple(output)
+
+        # Unify output form to tuple for easy correspondance with
+        # `act_send_info`
+        output_tuple = output if type(output) is tuple else (output,)
+        # Prepare for final output merge or reduction
+        self.output_chunks.append(output)
+
+        # Save activations and inputs for backward
+        flat_args = flatten_args(composite_args)
+        flat_kwargs = flatten_args(composite_kwargs)
+        flatten_input_tensors = flat_args + flat_kwargs
+        self.fwd_cache[self.fwd_chunk_id] = (
+            output_tuple,  # stage_output
+            flatten_input_tensors,  # input_values
+        )
+
+        logger.debug(
+            f"[{self.group_rank}] Forwarded chunk {self.fwd_chunk_id}, outputs: {map_debug_info(output)}"
+        )
+        self.fwd_chunk_id += 1
+        return output
+
+    def backward_one_chunk(
+        self,
+        loss=None,
+    ):
+        """
+        Perform backward pass on the module.
+        This should only be called once per microbatch.
+        """
+        (
+            stage_output,
+            input_values,
+        ) = self.fwd_cache.pop(self.bwd_chunk_id)
+
+        # Compute backward
+        if self.is_last:
+            # Last stage computes gradients from loss and has no gradients from
+            # next stage
+            bwd_kwargs = {
+                "stage_output": loss,
+                "output_grads": None,
+                "input_values": input_values,
+            }
+        else:
+            # Otherwise, receive gradients from next stage
+            grads_output = self._retrieve_recv_grads()
+            # If an input to the pipeline requires gradient,
+            # `torch.autograd.backward` will accumulate the gradient into the
+            # `.grad` field of such input
+            bwd_kwargs = {
+                "stage_output": stage_output,
+                "output_grads": grads_output,
+                "input_values": input_values,
+            }
+
+        self.grads_input = self.backward_maybe_with_nosync(
+            bwd_kwargs, self.bwd_chunk_id
+        )
+        logger.debug(
+            f"[{self.group_rank}] Backwarded chunk {self.bwd_chunk_id}"
+        )
+        self.bwd_chunk_id += 1
 
 
 def _make_tensor_from_meta(
@@ -184,27 +333,18 @@ class _PipelineStage(PipelineStageBase):
         stage_index: int,
         pipe_info: Pipe.PipeInfo,
         device: torch.device,
-        group: dist.ProcessGroup = None,
+        group: Optional[dist.ProcessGroup] = None,
     ):
         PipelineStageBase.__init__(
-            self, stage_index, pipe_info.num_stages, device, group
+            self,
+            stage_module,
+            stage_index,
+            pipe_info.num_stages,
+            device,
+            pipe_info.num_chunks,
+            group,
         )
-        self.submod = stage_module
         self.pipe_info = pipe_info
-        self.chunks = pipe_info.num_chunks
-
-        # `group_rank` is rank in process group `group`.
-        self.group_rank = dist.get_rank(group)
-
-        # Run time states
-        # map microbatch ID to list of forward tensor args
-        self.fwd_cache: Dict[int, Tuple[Any, List[torch.Tensor]]] = {}
-        # Current forward chunk id
-        self.fwd_chunk_id: int = 0
-        # Current backward chunk id
-        self.bwd_chunk_id: int = 0
-        # Caching chunk outputs for final output merge or reduction
-        self.output_chunks: List[Any] = []
 
         # Find stage nodes in graph
         submod_nodes = [
@@ -655,140 +795,6 @@ class _PipelineStage(PipelineStageBase):
         recv_infos = self.grad_recv_info[self.bwd_chunk_id]
         grads = self._map_tensor_from_recv_info(recv_infos)
         return grads
-
-    def forward_maybe_with_nosync(self, *args, **kwargs):
-        # If submod is wrapped with DDP, we use the `no_sync` context manager to
-        # avoid gradient all-reduce per microbatch
-        if isinstance(self.submod, DistributedDataParallel):
-            with self.submod.no_sync():  # type: ignore[operator]
-                out_val = self.submod(*args, **kwargs)
-        else:
-            out_val = self.submod(*args, **kwargs)
-        return out_val
-
-    def backward_maybe_with_nosync(self, bwd_kwargs: Dict, bwd_chunk_id: int):
-        if isinstance(self.submod, DistributedDataParallel):
-            if bwd_chunk_id == self.chunks - 1:
-                # Last chunk, prepare for gradient reduction
-                # HACK: reaching into DDP implementation details here. Is there a better way?
-                self.submod.reducer.prepare_for_backward(  # type: ignore[union-attr, operator]
-                    list(
-                        torch.nn.parallel.distributed._find_tensors(  # type: ignore[attr-defined]
-                            bwd_kwargs["stage_output"]
-                        )
-                    )
-                )
-                grads_input = stage_backward(**bwd_kwargs)
-            else:
-                with self.submod.no_sync():  # type: ignore[operator]
-                    grads_input = stage_backward(**bwd_kwargs)
-        else:
-            # Non-DDP submodule, regular backward
-            grads_input = stage_backward(**bwd_kwargs)
-
-        return grads_input
-
-    def forward_one_chunk(
-        self,
-        args: Tuple[Any, ...],
-        kwargs: Optional[Dict[str, Any]] = None,
-    ):
-        if self.is_first:
-            # First stage doesn't need to receive anything
-            composite_args = args
-            composite_kwargs = kwargs or {}
-        else:
-            # Receive activations for this chunk
-            # Activations only come in args form
-            composite_args = self._retrieve_recv_activations()
-            composite_kwargs = {}
-
-        # Compute forward
-        try:
-            output = self.forward_maybe_with_nosync(
-                *composite_args, **composite_kwargs
-            )
-
-        except Exception as e:
-            exc_msg = f"""
-            Rank {self.group_rank} failed to run forward stage: {self.name}
-            args: {map_debug_info(composite_args)}
-            kwargs: {map_debug_info(composite_kwargs)}
-            """
-            raise RuntimeError(exc_msg) from e
-
-        if type(output) is list:
-            # HACK: this is a hacky workaround for the fact that export creates
-            # output in list format
-            output = tuple(output)
-
-        # Unify output form to tuple for easy correspondance with
-        # `act_send_info`
-        output_tuple = output if type(output) is tuple else (output,)
-        # Prepare for final output merge or reduction
-        self.output_chunks.append(output)
-
-        # Save activations and inputs for backward
-        flat_args = flatten_args(composite_args)
-        flat_kwargs = flatten_args(composite_kwargs)
-        flatten_input_tensors = flat_args + flat_kwargs
-        self.fwd_cache[self.fwd_chunk_id] = (
-            output_tuple,  # stage_output
-            flatten_input_tensors,  # input_values
-        )
-
-        logger.debug(
-            f"[{self.group_rank}] Forwarded chunk {self.fwd_chunk_id}, outputs: {map_debug_info(output)}"
-        )
-        self.fwd_chunk_id += 1
-        return output
-
-    def backward_one_chunk(
-        self,
-        loss=None,
-    ):
-        (
-            stage_output,
-            input_values,
-        ) = self.fwd_cache.pop(self.bwd_chunk_id)
-
-        # Compute backward
-        if self.is_last:
-            # Last stage computes gradients from loss and has no gradients from
-            # next stage
-            bwd_kwargs = {
-                "stage_output": loss,
-                "output_grads": None,
-                "input_values": input_values,
-            }
-        else:
-            # Otherwise, receive gradients from next stage
-            grads_output = self._retrieve_recv_grads()
-            # If an input to the pipeline requires gradient,
-            # `torch.autograd.backward` will accumulate the gradient into the
-            # `.grad` field of such input
-            bwd_kwargs = {
-                "stage_output": stage_output,
-                "output_grads": grads_output,
-                "input_values": input_values,
-            }
-
-        self.grads_input = self.backward_maybe_with_nosync(
-            bwd_kwargs, self.bwd_chunk_id
-        )
-        logger.debug(
-            f"[{self.group_rank}] Backwarded chunk {self.bwd_chunk_id}"
-        )
-        self.bwd_chunk_id += 1
-
-    def clear_runtime_states(self):
-        # Reset pointers
-        self.fwd_chunk_id = 0
-        self.bwd_chunk_id = 0
-        # map microbatch ID to list of forward tensor args
-        self.fwd_cache.clear()
-        # Caching chunk outputs for final output merge or reduction
-        self.output_chunks.clear()
 
     def merge_outputs(self):
         # Last rank return merged results per original format

--- a/test/test_pipeline_stage.py
+++ b/test/test_pipeline_stage.py
@@ -1,0 +1,153 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from pippy import pipeline
+from pippy.IR import annotate_split_points, SplitPoint
+
+from pippy.ManualPipelineStage import ManualPipelineStage
+from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineStage import PipelineStage
+
+# torch.testing._internal.common_distributed requires "expecttest"
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import (
+    FILE_SCHEMA,
+    instantiate_parametrized_tests,
+    parametrize,
+)
+
+# Example models and helper utils
+##########################
+
+
+class MLP(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        hidden_dim: int,
+        out_dim: int,
+    ):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, out_dim, bias=False)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.w1(x)
+        x = self.w2(x)
+        x = self.relu(x)
+        return x
+
+
+# Tests defined below
+##########################
+
+
+# python -m unittest test_pipeline_stage.TestPipelineStage.<test>
+#               or
+# pytest test_pipeline_stage.py -vsk <test>
+class TestPipelineStage(MultiProcessTestCase):
+    @property
+    def world_size(self) -> int:
+        # covers first_stage, middle_stage, last_stage cases
+        return 2
+
+    @property
+    def init_method(self) -> str:
+        return f"{FILE_SCHEMA}{self.file_name}"
+
+    def setUp(self):
+        super().setUp()
+        # starts world_size processes
+        self._spawn_processes()
+
+    def init_distributed(self, use_cuda):
+        if use_cuda:
+            torch.cuda.set_device(self.rank)
+            dist.init_process_group(
+                init_method=self.init_method,
+                backend="nccl",
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+        else:
+            dist.init_process_group(
+                init_method=self.init_method,
+                backend="gloo",
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+
+    @parametrize("pipeline_stage_type", ["manual", "tracing"])
+    def test_pipeline_stage(self, pipeline_stage_type):
+        # TODO: parameterize
+        use_cuda = True
+
+        device = (
+            torch.device(f"cuda:{self.rank}")
+            if use_cuda
+            else torch.device("cpu")
+        )
+        self.init_distributed(use_cuda=use_cuda)
+
+        in_dim = hidden_dim = out_dim = 10
+        model = MLP(dim=in_dim, hidden_dim=hidden_dim, out_dim=out_dim).to(
+            device
+        )
+        batch_size = 32
+        example_input = torch.randn(batch_size, in_dim, device=device)
+        chunks = 2
+
+        if pipeline_stage_type == "tracing":
+            annotate_split_points(
+                model,
+                {
+                    "w1": SplitPoint.END,
+                },
+            )
+            pipe = pipeline(model, chunks, example_args=(example_input,))
+            stage = PipelineStage(pipe, self.rank, device)
+        elif pipeline_stage_type == "manual":
+            stage = ManualPipelineStage(
+                model,
+                self.rank,
+                self.world_size,
+                device,
+                chunks,
+                input_args=example_input.chunk(chunks)[0],
+            )
+        else:
+            raise ValueError(
+                f"Unknown pipeline stage type {pipeline_stage_type}"
+            )
+
+        # Define a loss function
+        loss_fn = torch.nn.MSELoss(reduction="sum")
+
+        # Attach to a schedule
+        schedule = PipelineScheduleGPipe(stage, chunks, loss_fn=loss_fn)
+
+        # Input data
+        x = torch.randn(batch_size, in_dim, device=device)
+        target = torch.randn(batch_size, out_dim, device=device)
+
+        # Run the pipeline with input `x`. Divide the batch into 4 micro-batches
+        # and run them in parallel on the pipeline
+        if self.rank == 0:
+            schedule.step(x)
+        elif self.rank == self.world_size - 1:
+            losses = []
+            output = schedule.step(target=target, losses=losses)
+        else:
+            schedule.step()
+
+
+instantiate_parametrized_tests(TestPipelineStage)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/pytorch/PiPPy/issues/1005

Changes:

- Unify the `forward_one_chunk` and `backward_one_chunk` to be used by both `PipelineStage` and `ManualPipelineStage`
- Add `test_pipeline_stage` to test both `PipelineStage` and `ManualPipelineStage` can be used interchangeably and without error.

TODO:
- create test verify that the outputs for both manual pipeline stage and pipeline stage are equivalent