### PR TITLE
Remove incorrect assertion on loss shapes

### DIFF
--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -102,10 +102,6 @@ class PipelineSchedule(ABC):
         return arg_mbs, kwarg_mbs
 
     def _compute_loss(self, output, target):
-        if target.shape != output.shape:
-            raise RuntimeError(
-                f"target shape {target.shape} does not match output shape {output.shape}"
-            )
         return self._loss_fn(output, target)  # type: ignore[misc]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1028
* __->__ #1025

output and target shapes are expected to differ.

It might be possible to craft some shape-checking logic here, but it
would need to account for various loss functions and be general, not
sure its feasible. Removing for now to unblock.

(using cross-entropy loss in this case- see docs about expected shapes
https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html)