### PR TITLE
Unwrap output_vals in _create_grad_recv_info

### DIFF
--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -415,6 +415,9 @@ class PipelineStage(PipelineStageBase, QualnameMapMixin):
         # The output node may take multiple args, meaning the submod having multiple output values.
         output_vals = output_node.args
 
+        # output vals is packaged in a wrapper tuple that must be shed before iterating its inner tuple's contents
+        output_vals = output_vals[0]
+
         for out_idx, dst_list in act_send_info.items():
             if not dst_list:
                 # No actual receiver for activation so no grad coming back

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -415,8 +415,9 @@ class PipelineStage(PipelineStageBase, QualnameMapMixin):
         # The output node may take multiple args, meaning the submod having multiple output values.
         output_vals = output_node.args
 
-        # output vals is packaged in a wrapper tuple that must be shed before iterating its inner tuple's contents
-        output_vals = output_vals[0]
+        # output vals is sometimes packaged in a wrapper tuple that must be shed
+        if isinstance(output_vals[0], tuple):
+            output_vals = output_vals[0]
 
         for out_idx, dst_list in act_send_info.items():
             if not dst_list:

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -413,11 +413,7 @@ class PipelineStage(PipelineStageBase, QualnameMapMixin):
         assert len(output_nodes) == 1
         output_node = output_nodes[0]
         # The output node may take multiple args, meaning the submod having multiple output values.
-        output_vals = output_node.args
-
-        # output vals is sometimes packaged in a wrapper tuple that must be shed
-        if isinstance(output_vals[0], tuple):
-            output_vals = output_vals[0]
+        output_vals = flatten_args(output_node.args)
 
         for out_idx, dst_list in act_send_info.items():
             if not dst_list:

--- a/test/test_bwd.py
+++ b/test/test_bwd.py
@@ -37,9 +37,11 @@ class ExampleCode(torch.nn.Module):
         x = torch.relu(x)
         pipe_split()
         x = torch.mm(x, self.mm_param1)
+        skip = x
         x = self.lin1(x)
         pipe_split()
-        x = torch.relu(x)
+        # force a skip-connection to test multiple outputs/grads between stages
+        x = torch.relu(x) + skip
         x = torch.mm(x, self.mm_param2)
         pipe_split()
         x = self.lin2(x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1029
* __->__ #1028

Verified test case catches the error if the fix is commented.

Note: I'm not sure why the 'output' node is only _sometimes_ packaged in
a tuple.  I found that for example `torchrun --nproc-per-node 3
examples/basic/example_train.py` would fail if I unconditionally
unwrapped the output tuple.  The current solution is tenuous at best,
but seems to pass tests.