### PR TITLE
Fix sending values that don't require_grad

### DIFF
--- a/test/test_bwd.py
+++ b/test/test_bwd.py
@@ -29,15 +29,18 @@ class ExampleCode(torch.nn.Module):
         self.mm_param0 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
         self.mm_param1 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
         self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.register_buffer("cval", torch.randn((d_hid,), requires_grad=False))
         self.lin1 = torch.nn.Linear(d_hid, d_hid)
         self.lin2 = torch.nn.Linear(d_hid, d_hid)
 
     def forward(self, x):
         x = torch.mm(x, self.mm_param0)
         x = torch.relu(x)
+        a_constant = self.cval.clone()
         pipe_split()
         x = torch.mm(x, self.mm_param1)
-        skip = x
+        # try passing a value that doesn't require_grad across skip boundaries
+        skip = x + a_constant
         x = self.lin1(x)
         pipe_split()
         # force a skip-connection to test multiple outputs/grads between stages


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1029
* #1028

Previously sending a value between stages when the value does not
require_grad would lead to this error

```
[rank0]:   File "/data/users/whc/pippy/pippy/PipelineSchedule.py", line
232, in step
[rank0]:     self.step_microbatches(args_split, kwargs_split,
targets_split, losses)
[rank0]:   File "/data/users/whc/pippy/pippy/PipelineSchedule.py", line
197, in step_microbatches
[rank0]:     self._stage.backward_one_chunk(loss=loss)
[rank0]:   File "/data/users/whc/pippy/pippy/PipelineStage.py", line
773, in backward_one_chunk
[rank0]:     torch.autograd.backward(
[rank0]:   File "/data/users/whc/pytorch/torch/autograd/__init__.py",
line 267, in backward
[rank0]:     _engine_run_backward(
[rank0]:   File "/data/users/whc/pytorch/torch/autograd/graph.py", line
767, in _engine_run_backward
[rank0]:     return Variable._execution_engine.run_backward(  # Calls
into the C++ engine to run the backward pass
[rank0]: RuntimeError: element 1 of tensors does not require grad and
does not have a grad_fn
```