### PR TITLE
Bring back stage_backward helper

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -189,9 +189,6 @@ def _insert_stage_symbolic_backward(
         val_to_grad[forward_node] = grad_value
 
     with g.inserting_before(output_node):
-        # TODO: remove barrier_tokens
-        barrier_tokens = []
-
         for node in reversed(g.nodes):
             if node not in live_nodes:
                 continue
@@ -235,17 +232,10 @@ def _insert_stage_symbolic_backward(
                 )
                 # Insert backward stage debug info
                 kwargs_copy = dict(grad_call.kwargs)
-                kwargs_copy[
-                    "stage_info"
-                ] = f"{grad_call} for stage {node.format_node()}"
                 grad_call.kwargs = kwargs_copy
 
                 grad_call_proxy = fx.Proxy(grad_call)
-                grads, barrier_token = (
-                    grad_call_proxy[0].node,
-                    grad_call_proxy[1].node,
-                )
-                barrier_tokens.append(barrier_token)
+                grads = grad_call_proxy.node
 
                 input_nodes = list(node.all_input_nodes)
                 grads_proxy = fx.Proxy(grads)

--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -667,9 +667,6 @@ class _PipelineStage(PipelineStageBase):
         return out_val
 
     def backward_maybe_with_nosync(self, bwd_kwargs: Dict, bwd_chunk_id: int):
-        # Add `stage_info` for debug purpose in `stage_backward`
-        bwd_kwargs["stage_info"] = f"{self.stage_index}"
-
         if isinstance(self.submod, DistributedDataParallel):
             if bwd_chunk_id == self.chunks - 1:
                 # Last chunk, prepare for gradient reduction

--- a/pippy/backward.py
+++ b/pippy/backward.py
@@ -10,7 +10,6 @@ def stage_backward(
     stage_output,
     output_grads,
     input_values,
-    stage_info: Optional[str] = None,  # debug purpose
     outputs_with_grads_idxs: Optional[List[int]] = None,  # deprecated, not used
 ):
     """
@@ -19,9 +18,13 @@ def stage_backward(
     in the autograd trace) as well as return a list of the gradients for the
     input values
     """
+    if outputs_with_grads_idxs is not None:
+        # Deprecated, not used in runtime calls, only exists in compiler
+        stage_output = [stage_output[i] for i in outputs_with_grads_idxs]
+        output_grads = [output_grads[i] for i in outputs_with_grads_idxs]
 
     try:
-        # stage_outputs may be a composite datatype like dict. Extract all individual
+        # stage_output may be a composite datatype like dict. Extract all individual
         # tensor values here
         stage_output_tensors = []
         output_grad_tensors = []
@@ -85,7 +88,7 @@ def stage_backward(
 
     except Exception as e:
         exc_msg = f"""
-        Failed to run backward on stage {stage_info}
+        Failed to run stage backward:
         Stage output: {map_debug_info(stage_output)}
         Output gradient: {map_debug_info(output_grads)}
         Input: {map_debug_info(input_values)}

--- a/pippy/backward.py
+++ b/pippy/backward.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -10,8 +10,8 @@ def stage_backward(
     stage_output,
     output_grads,
     input_values,
-    stage_info: str,
-    outputs_with_grads_idxs: List[int],
+    stage_info: Optional[str] = None,  # debug purpose
+    outputs_with_grads_idxs: Optional[List[int]] = None,  # deprecated, not used
 ):
     """
     Given the input value(s) and the corresponding gradient for the output
@@ -21,14 +21,7 @@ def stage_backward(
     """
 
     try:
-        stage_output_with_grads = [
-            stage_output[i] for i in outputs_with_grads_idxs
-        ]
-        output_grads_with_grads = [
-            output_grads[i] for i in outputs_with_grads_idxs
-        ]
-
-        # stage_output may be a composite datatype like dict. Extract all individual
+        # stage_outputs may be a composite datatype like dict. Extract all individual
         # tensor values here
         stage_output_tensors = []
         output_grad_tensors = []
@@ -62,14 +55,13 @@ def stage_backward(
                 # Output is a non-tensor type; just ignore it
                 pass
 
-        extract_tensors_with_grads(
-            stage_output_with_grads, output_grads_with_grads
-        )
+        extract_tensors_with_grads(stage_output, output_grads)
 
         torch.autograd.backward(
             stage_output_tensors, grad_tensors=output_grad_tensors  # type: ignore[arg-type]
         )
 
+        # Extract gradients wrt the input values
         grad_inputs = []
         for val in input_values:
             if isinstance(val, torch.Tensor):
@@ -77,7 +69,9 @@ def stage_backward(
             else:
                 grad_inputs.append(None)
 
-        # TODO: use `torch.autograd.grad`
+        # Alternative impl: `torch.autograd.grad`.
+        # Note that `torch.autograd.grad` will not accumulate gradients into the
+        # model's parameters.
         """
         inputs_with_grad = []
         for val in input_values:
@@ -91,19 +85,14 @@ def stage_backward(
 
     except Exception as e:
         exc_msg = f"""
-        Failed to run backward stage {stage_info}
+        Failed to run backward on stage {stage_info}
         Stage output: {map_debug_info(stage_output)}
         Output gradient: {map_debug_info(output_grads)}
         Input: {map_debug_info(input_values)}
         """
         raise RuntimeError(exc_msg) from e
 
-    barrier_token = None
-    return grad_inputs, barrier_token
-
-
-def sync_barrier(loss, barrier_tokens, last_grads):
-    return loss, last_grads
+    return grad_inputs
 
 
 # TODO: handling requires_grad=False dynamically. Can we analyze this during initial


### PR DESCRIPTION
https://github.com/pytorch/PiPPy/pull/1029 reminds us of the need to extract outputs that requires grad. 

So I am bringing pippy's previous `stage_backward` helper back in action.

This helper has extraction functions for general cases.

Also brings back `backward_maybe_with_no_sync` to support DDP.

Cc: @wconstab 