### PR TITLE
Remove no-backward warning

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -1044,7 +1044,7 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
         has_loss_and_backward = False
         generated_loss_spec = output_loss_value_spec
 
-        if mod.training or output_loss_value_spec is not None:
+        if output_loss_value_spec is not None:
             loss_node, output_node, generated_loss_spec = _find_loss_output(
                 mod, split.graph, output_loss_value_spec
             )
@@ -1056,17 +1056,15 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
                 )
                 split.recompile()
                 has_loss_and_backward = True
-                logger.info(
+                logger.debug(
                     "Pipeline is in training mode, backward pass generated"
                 )
             else:
-                logger.info(
-                    "Did not find any loss value from model output, your pipeline will be in inference mode. "
-                    "If you want your pipeline to be in training mode, please specify a loss value via "
-                    "`output_loss_value_spec`."
+                raise RuntimeError(
+                    f"Did not find any loss value according to {output_loss_value_spec=}"
                 )
         else:
-            logger.info(
+            logger.debug(
                 "Pipeline is in inference mode, backward pass not generated"
             )
 


### PR DESCRIPTION
Previous we tried to generate backward as long as model.training is true, and warn if no loss value is found.
Since default value for model.training is true, this warning has caused confusion.