### PR TITLE
Use PiPPy to distribute Mixture of Experts

### DIFF
--- a/examples/mixture_of_experts/dist_moe.py
+++ b/examples/mixture_of_experts/dist_moe.py
@@ -1,5 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+
+# Minimum effort to run this example:
 # torchrun --nproc-per-node 5 dist_moe.py
+# You need use 5 ranks because there are 3 experts, one pre-processor and one gatherer.
+
+"""
+                pre-proc
+            /       |       \
+    expert 0    expert 1   expert 2
+            \       |       /
+                gatherer
+"""
 
 import torch
 import torch.distributed as dist
@@ -16,13 +27,13 @@ torch.manual_seed(0)
 
 # Each expert is a MLP
 class ExpertLayer(torch.nn.Module):
-    def __init__(self, d_hid):
+    def __init__(self, d_hid) -> None:
         super(ExpertLayer, self).__init__()
         self.net1 = torch.nn.Linear(d_hid, d_hid)
         self.relu = torch.nn.ReLU()
         self.net2 = torch.nn.Linear(d_hid, d_hid)
 
-    def forward(self, x):
+    def forward(self, x) -> torch.Tensor:
         x = self.net1(x)
         x = self.relu(x)
         x = self.net2(x)

--- a/examples/mixture_of_experts/dist_moe.py
+++ b/examples/mixture_of_experts/dist_moe.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# torchrun --nproc-per-node 5 dist_moe.py
+
+import torch
+import torch.distributed as dist
+
+import pippy
+from pippy import annotate_split_points, pipeline, PipelineStage, SplitPoint
+from pippy.PipelineSchedule import PipelineScheduleGPipe
+
+
+d_hid = 16
+n_experts = 3
+batch_size = 4
+
+torch.manual_seed(0)
+
+# Each expert is a MLP
+class ExpertLayer(torch.nn.Module):
+    def __init__(self, d_hid):
+        super(ExpertLayer, self).__init__()
+        self.net1 = torch.nn.Linear(d_hid, d_hid)
+        self.relu = torch.nn.ReLU()
+        self.net2 = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x):
+        x = self.net1(x)
+        x = self.relu(x)
+        x = self.net2(x)
+        return x
+
+# Full model comprising n experts
+class MoE(torch.nn.Module):
+    def __init__(self, n_experts: int) -> None:
+        super().__init__()
+        self.pre_proc = torch.nn.Linear(d_hid, d_hid)
+        self.experts = torch.nn.ModuleList(
+            [
+                ExpertLayer(d_hid)
+                for _ in range(n_experts)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pre_proc(x)
+        outputs = []
+        for expert in self.experts:
+            outputs.append(expert(x))
+        return torch.cat(outputs, dim=1)
+
+
+dist.init_process_group()
+rank = dist.get_rank()
+world_size = dist.get_world_size()
+device = torch.device(f"cuda:{rank}")
+
+model = MoE(n_experts)
+x = torch.randn(batch_size, d_hid)
+
+# Mark the split point for each expert
+annotate_split_points(model, {f"pre_proc": SplitPoint.END})
+for i in range(n_experts):
+    annotate_split_points(
+        model, {f"experts.{i}": SplitPoint.END}
+    )
+
+pippy_model = pipeline(model, 1, (x,))
+
+assert pippy_model.num_stages == world_size
+if rank == 0:
+    print("Original model:\n", model)
+    print("PiPPy model:")
+    pippy_model.print_readable()
+
+# Check representation equivalence
+ref_out = model(x)
+pippy_out = pippy_model(x)[0]
+torch.testing.assert_close(pippy_out, ref_out)
+print(f"PiPPy model equivalent: {torch.sum(pippy_out)} ref {torch.sum(ref_out)}")
+
+# Create distributed runtime
+expert = PipelineStage(pippy_model, rank, device=device)
+
+# Attach to a schedule
+# Use a microbatch of 1, i.e. no pipelining
+schedule = PipelineScheduleGPipe(expert, 1)
+if rank == 0:
+    x = x.to(device)
+    schedule.step(x)
+else:
+    dist_out = schedule.step()
+
+# Check equivalence
+if rank == dist.get_world_size() - 1:
+    print(f"Distributed model equivalent: {torch.sum(dist_out)} ref {torch.sum(ref_out)}")
+    print(f"dist_out: {dist_out.shape}")
+    print(f"ref_out: {ref_out.shape}")

--- a/examples/mixture_of_experts/dist_moe.py
+++ b/examples/mixture_of_experts/dist_moe.py
@@ -4,7 +4,6 @@
 import torch
 import torch.distributed as dist
 
-import pippy
 from pippy import annotate_split_points, pipeline, PipelineStage, SplitPoint
 from pippy.PipelineSchedule import PipelineScheduleGPipe
 


### PR DESCRIPTION
Demonstrate an extended use of PiPPy: distribute MoE models along the expert dimension.

```
PiPPy model:
class GraphModule(torch.nn.Module):
    def forward(self, arg14_1: "f32[4, 16]"):
        # No stacktrace found for following nodes
        submod_0 = self.submod_0(arg14_1);  arg14_1 = None
        submod_3 = self.submod_3(submod_0)
        submod_2 = self.submod_2(submod_0)
        submod_1 = self.submod_1(submod_0);  submod_0 = None
        submod_4 = self.submod_4(submod_1, submod_2, submod_3);  submod_1 = submod_2 = submod_3 = None
        return (submod_4,)
        
    class GraphModule(torch.nn.Module):
        def forward(self, arg_0):
            arg14_1: "f32[4, 16]"; 
        
            arg14_1, = fx_pytree.tree_flatten_spec(([arg_0], {}), self._in_spec)
            # No stacktrace found for following nodes
            pre_proc: "f32[4, 16]" = self.pre_proc(arg14_1);  arg14_1 = None
            return pre_proc
            
    class GraphModule(torch.nn.Module):
        def forward(self, addmm: "f32[4, 16]"):
            # No stacktrace found for following nodes
            experts_2: "f32[4, 16]" = getattr(self.experts, "2")(addmm);  addmm = None
            return experts_2
            
    class GraphModule(torch.nn.Module):
        def forward(self, addmm: "f32[4, 16]"):
            # No stacktrace found for following nodes
            experts_1: "f32[4, 16]" = getattr(self.experts, "1")(addmm);  addmm = None
            return experts_1
            
    class GraphModule(torch.nn.Module):
        def forward(self, addmm: "f32[4, 16]"):
            # No stacktrace found for following nodes
            experts_0: "f32[4, 16]" = getattr(self.experts, "0")(addmm);  addmm = None
            return experts_0
            
    class GraphModule(torch.nn.Module):
        def forward(self, addmm_2: "f32[4, 16]", addmm_4: "f32[4, 16]", addmm_6: "f32[4, 16]"):
            # File: /data/users/kw2501/PiPPy/examples/MoE/dist_moe.py:47 in forward, code: return torch.cat(outputs, dim=1)
            cat_default: "f32[4, 48]" = torch.ops.aten.cat.default([addmm_2, addmm_4, addmm_6], 1);  addmm_2 = addmm_4 = addmm_6 = None
            return cat_default
            
PiPPy model equivalent: 2.4520821571350098 ref 2.4520821571350098
NCCL version 2.20.5+cuda12.4
Distributed model equivalent: 2.4520821571350098 ref 2.4520821571350098
dist_out: torch.Size([4, 48])
ref_out: torch.Size([4, 48])
```