### PR TITLE
Rename Schedules

### DIFF
--- a/examples/basic/example.py
+++ b/examples/basic/example.py
@@ -6,7 +6,7 @@ import os
 import torch
 from pippy import pipeline
 from pippy.IR import annotate_split_points, SplitPoint
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 in_dim = 512
@@ -105,7 +105,7 @@ dist.init_process_group(rank=rank, world_size=world_size)
 stage = PipelineStage(pipe, rank, device)
 
 # Attach to a schedule
-schedule = PipelineScheduleGPipe(stage, chunks)
+schedule = ScheduleGPipe(stage, chunks)
 
 # Input data
 x = torch.randn(batch_size, in_dim, device=device)

--- a/examples/basic/example_train.py
+++ b/examples/basic/example_train.py
@@ -5,7 +5,7 @@
 import os
 import torch
 from pippy.IR import annotate_split_points, SplitPoint
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 in_dim = 512
@@ -108,7 +108,7 @@ stage = PipelineStage(pipe, rank, device)
 loss_fn=torch.nn.MSELoss(reduction="sum")
 
 # Attach to a schedule
-schedule = PipelineScheduleGPipe(stage, chunks, loss_fn=loss_fn)
+schedule = ScheduleGPipe(stage, chunks, loss_fn=loss_fn)
 
 # Input data
 x = torch.randn(batch_size, in_dim, device=device)

--- a/examples/cpu_init/gpt2_cpu_init.py
+++ b/examples/cpu_init/gpt2_cpu_init.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import GPT2ForSequenceClassification, GPT2Config
@@ -66,7 +66,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Real input on GPU
     real_input = torch.randint(

--- a/examples/huggingface/pippy_albert.py
+++ b/examples/huggingface/pippy_albert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import AlbertForMaskedLM, AlbertConfig
@@ -72,7 +72,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_bart.py
+++ b/examples/huggingface/pippy_bart.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BartForCausalLM, BartConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_bert.py
+++ b/examples/huggingface/pippy_bert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BertForMaskedLM, BertConfig
@@ -69,7 +69,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_blenderbot.py
+++ b/examples/huggingface/pippy_blenderbot.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import BlenderbotForCausalLM, BlenderbotConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_camemBert.py
+++ b/examples/huggingface/pippy_camemBert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import CamembertForMaskedLM, CamembertConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_convBert.py
+++ b/examples/huggingface/pippy_convBert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import ConvBertForMaskedLM, ConvBertConfig
@@ -75,7 +75,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_deberta.py
+++ b/examples/huggingface/pippy_deberta.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DebertaForMaskedLM, DebertaConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_debertaV2.py
+++ b/examples/huggingface/pippy_debertaV2.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DebertaV2ForMaskedLM, DebertaConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_distilBert.py
+++ b/examples/huggingface/pippy_distilBert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import DistilBertForMaskedLM, DistilBertConfig
@@ -74,7 +74,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_electra.py
+++ b/examples/huggingface/pippy_electra.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import ElectraForCausalLM, ElectraConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_fnet.py
+++ b/examples/huggingface/pippy_fnet.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import FNetForMaskedLM, FNetConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_gpt2.py
+++ b/examples/huggingface/pippy_gpt2.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import GPT2ForSequenceClassification, GPT2Config
@@ -88,7 +88,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_gptNeo.py
+++ b/examples/huggingface/pippy_gptNeo.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import GPTNeoForCausalLM, GPTNeoConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_layoutLM.py
+++ b/examples/huggingface/pippy_layoutLM.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import LayoutLMForMaskedLM, LayoutLMConfig
@@ -77,7 +77,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_m2m100.py
+++ b/examples/huggingface/pippy_m2m100.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import M2M100ForConditionalGeneration, M2M100Config
@@ -73,7 +73,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_mbart.py
+++ b/examples/huggingface/pippy_mbart.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MBartForCausalLM, MBartConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_megatronBert.py
+++ b/examples/huggingface/pippy_megatronBert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MegatronBertForCausalLM, MegatronBertConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_mobileBert.py
+++ b/examples/huggingface/pippy_mobileBert.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MobileBertForMaskedLM, MobileBertConfig
@@ -74,7 +74,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_mt5.py
+++ b/examples/huggingface/pippy_mt5.py
@@ -17,7 +17,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import MT5ForConditionalGeneration, MT5Config
@@ -88,7 +88,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_opt.py
+++ b/examples/huggingface/pippy_opt.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import OPTForCausalLM, OPTConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_pegasus.py
+++ b/examples/huggingface/pippy_pegasus.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import PegasusForCausalLM, PegasusConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_plBart.py
+++ b/examples/huggingface/pippy_plBart.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import PLBartForCausalLM, PLBartConfig
@@ -77,7 +77,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_t5.py
+++ b/examples/huggingface/pippy_t5.py
@@ -18,7 +18,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import T5ForConditionalGeneration, T5Config
@@ -88,7 +88,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_trOCR.py
+++ b/examples/huggingface/pippy_trOCR.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import TrOCRForCausalLM, TrOCRConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_unet.py
+++ b/examples/huggingface/pippy_unet.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from diffusers import UNet2DModel
@@ -61,7 +61,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/huggingface/pippy_xlnet.py
+++ b/examples/huggingface/pippy_xlnet.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 
 from pippy import pipeline
 from pippy.IR import SplitPoint, annotate_split_points
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 from transformers import XLNetLMHeadModel, XLNetConfig
@@ -70,7 +70,7 @@ def run(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/examples/llama/pippy_llama.py
+++ b/examples/llama/pippy_llama.py
@@ -3,7 +3,7 @@ import os
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from pippy import SplitPoint, annotate_split_points, pipeline, PipelineStage
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 
 # Grab the model
 llama = AutoModelForCausalLM.from_pretrained(
@@ -37,7 +37,7 @@ torch.distributed.init_process_group(rank=rank, world_size=world_size)
 stage = PipelineStage(llama_pipe, rank, device=device)
 
 # Attach to a schedule
-schedule = PipelineScheduleGPipe(stage, world_size)
+schedule = ScheduleGPipe(stage, world_size)
 
 # Run
 if rank == 0:

--- a/examples/mixture_of_experts/dist_moe.py
+++ b/examples/mixture_of_experts/dist_moe.py
@@ -16,7 +16,7 @@ import torch
 import torch.distributed as dist
 
 from pippy import annotate_split_points, pipeline, PipelineStage, SplitPoint
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 
 
 d_hid = 16
@@ -93,7 +93,7 @@ expert = PipelineStage(pippy_model, rank, device=device)
 
 # Attach to a schedule
 # Use a microbatch of 1, i.e. no pipelining
-schedule = PipelineScheduleGPipe(expert, 1)
+schedule = ScheduleGPipe(expert, 1)
 if rank == 0:
     x = x.to(device)
     schedule.step(x)

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -130,7 +130,7 @@ def sorted_batch_isend_irecv(p2p_ops: List[dist.P2POp]) -> Dict[int, dist.Work]:
     return work_by_peer
 
 
-class PipelineScheduleGPipe(PipelineSchedule):
+class ScheduleGPipe(PipelineSchedule):
     def step_microbatches(
         self,
         arg_mbs: Optional[List] = None,
@@ -235,7 +235,7 @@ class PipelineScheduleGPipe(PipelineSchedule):
         return self._stage.merge_outputs()
 
 
-class PipelineSchedule1F1B(PipelineSchedule):
+class Schedule1F1B(PipelineSchedule):
     def step_microbatches(
         self,
         arg_mbs: Optional[List] = None,
@@ -359,7 +359,7 @@ class PipelineSchedule1F1B(PipelineSchedule):
         return self._stage.merge_outputs()
 
 
-class PipelineScheduleLoopedBFS(PipelineSchedule):
+class ScheduleLoopedBFS(PipelineSchedule):
     def __init__(self, stages: List[PipelineStageBase]):
         self._stages = stages
 
@@ -412,7 +412,7 @@ class PipelineScheduleLoopedBFS(PipelineSchedule):
         pass
 
 
-class PipelineScheduleInterleaved1F1B(PipelineSchedule):
+class ScheduleInterleaved1F1B(PipelineSchedule):
     def __init__(self, stages: List[PipelineStageBase]):
         if len(stages) <= 1:
             raise ValueError(

--- a/test/test_autosplit.py
+++ b/test/test_autosplit.py
@@ -8,7 +8,7 @@ import pippy
 import torch
 import torch.distributed as dist
 from pippy import pipeline, split_into_equal_size
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
@@ -70,7 +70,7 @@ def run_worker(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/test/test_bwd.py
+++ b/test/test_bwd.py
@@ -7,13 +7,13 @@ import torch
 import torch.distributed as dist
 
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineSchedule1F1B, PipelineScheduleGPipe
+from pippy.PipelineSchedule import Schedule1F1B, ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
 schedule_map = {
-    "gpipe": PipelineScheduleGPipe,
-    "1f1b": PipelineSchedule1F1B,
+    "gpipe": ScheduleGPipe,
+    "1f1b": Schedule1F1B,
 }
 
 d_hid = 512

--- a/test/test_fwd.py
+++ b/test/test_fwd.py
@@ -8,7 +8,7 @@ import pippy
 import torch
 import torch.distributed as dist
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
@@ -66,7 +66,7 @@ def run_worker(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -11,13 +11,13 @@ import torch.distributed as dist
 import torch.optim as optim
 
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineSchedule1F1B, PipelineScheduleGPipe
+from pippy.PipelineSchedule import Schedule1F1B, ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
 schedule_map = {
-    "gpipe": PipelineScheduleGPipe,
-    "1f1b": PipelineSchedule1F1B,
+    "gpipe": ScheduleGPipe,
+    "1f1b": Schedule1F1B,
 }
 
 d_hid = 512

--- a/test/test_pipeline_schedule.py
+++ b/test/test_pipeline_schedule.py
@@ -17,8 +17,8 @@ from pippy.ManualPipelineStage import (
 
 from pippy.PipelineSchedule import (
     logger as schedule_logger,
-    PipelineSchedule1F1B,
-    PipelineScheduleInterleaved1F1B,
+    Schedule1F1B,
+    ScheduleInterleaved1F1B,
 )
 
 # torch.testing._internal.common_distributed requies "expecttest"
@@ -298,7 +298,7 @@ class TestPipelineSchedule(MultiProcessTestCase):
             [torch.randn_like(microbatch)] for _ in range(num_microbatches)
         ]
 
-        schedule = PipelineSchedule1F1B(stage, num_microbatches)
+        schedule = Schedule1F1B(stage, num_microbatches)
         schedule.step_microbatches(microbatches)
         dist.barrier()
 
@@ -324,7 +324,7 @@ class TestPipelineSchedule(MultiProcessTestCase):
             torch.randn_like(microbatch) for _ in range(num_microbatches)
         ]
 
-        schedule = PipelineScheduleInterleaved1F1B(stages)
+        schedule = ScheduleInterleaved1F1B(stages)
         schedule.step(microbatches)
 
         # num local pipeline stages == world_size
@@ -336,7 +336,7 @@ class TestPipelineSchedule(MultiProcessTestCase):
             torch.randn_like(microbatch) for _ in range(num_microbatches)
         ]
 
-        schedule = PipelineScheduleInterleaved1F1B(stages)
+        schedule = ScheduleInterleaved1F1B(stages)
         schedule.step(microbatches)
 
         # differing microbatch size
@@ -363,12 +363,12 @@ class TestPipelineSchedule(MultiProcessTestCase):
             stages = self._create_virtual_pipeline_stages(
                 model, microbatch, device, 1
             )
-            PipelineScheduleInterleaved1F1B(stages)
+            ScheduleInterleaved1F1B(stages)
 
         stages = self._create_virtual_pipeline_stages(
             model, microbatch, device, 4
         )
-        schedule = PipelineScheduleInterleaved1F1B(stages)
+        schedule = ScheduleInterleaved1F1B(stages)
 
         # invalid microbatch values
         with self.assertRaises(ValueError):

--- a/test/test_pipeline_schedule_e2e.py
+++ b/test/test_pipeline_schedule_e2e.py
@@ -28,10 +28,10 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 from pippy.ManualPipelineStage import ManualPipelineStage
 from pippy.PipelineSchedule import (
-    PipelineSchedule1F1B,
-    PipelineScheduleGPipe,
-    PipelineScheduleInterleaved1F1B,
-    PipelineScheduleLoopedBFS,
+    Schedule1F1B,
+    ScheduleGPipe,
+    ScheduleInterleaved1F1B,
+    ScheduleLoopedBFS,
 )
 
 from torch.distributed._tensor.device_mesh import init_device_mesh
@@ -201,13 +201,13 @@ def main(**kwargs):
     for schedule in kwargs["schedules"]:
         logger.info(f"====== Rank {rank} running schedule {schedule} ======")
         if schedule == "gpipe":
-            pipeline = PipelineScheduleGPipe(stage_model, n_microbatches)
+            pipeline = ScheduleGPipe(stage_model, n_microbatches)
         elif schedule == "1f1b":
-            pipeline = PipelineSchedule1F1B(stage_model, n_microbatches)
+            pipeline = Schedule1F1B(stage_model, n_microbatches)
         elif schedule == "looped_bfs":
-            pipeline = PipelineScheduleLoopedBFS(stage_model_looped)
+            pipeline = ScheduleLoopedBFS(stage_model_looped)
         elif schedule == "interleaved_1f1b":
-            pipeline = PipelineScheduleInterleaved1F1B(stage_model_looped)
+            pipeline = ScheduleInterleaved1F1B(stage_model_looped)
 
         if _run_profiler:
             logger.info(f"====== Rank {rank} profile ======")

--- a/test/test_pipeline_stage.py
+++ b/test/test_pipeline_stage.py
@@ -10,7 +10,7 @@ from pippy import pipeline
 from pippy.IR import annotate_split_points, SplitPoint
 
 from pippy.ManualPipelineStage import ManualPipelineStage
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 # torch.testing._internal.common_distributed requires "expecttest"
@@ -130,7 +130,7 @@ class TestPipelineStage(MultiProcessTestCase):
         loss_fn = torch.nn.MSELoss(reduction="sum")
 
         # Attach to a schedule
-        schedule = PipelineScheduleGPipe(stage, chunks, loss_fn=loss_fn)
+        schedule = ScheduleGPipe(stage, chunks, loss_fn=loss_fn)
 
         # Input data
         x = torch.randn(batch_size, in_dim, device=device)

--- a/test/test_pipeline_with_ddp.py
+++ b/test/test_pipeline_with_ddp.py
@@ -5,7 +5,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from pippy.ManualPipelineStage import ManualPipelineStage
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from torch.distributed.device_mesh import init_device_mesh
 
 # torch.testing._internal.common_distributed requies "expecttest"
@@ -162,7 +162,7 @@ class TestPipelineDDP(MultiProcessTestCase):
             num_microbatches,
         )
 
-        pipeline_schedule = PipelineScheduleGPipe(
+        pipeline_schedule = ScheduleGPipe(
             pipeline_stage,
             n_microbatches=num_microbatches,
         )

--- a/test/test_skip_conn.py
+++ b/test/test_skip_conn.py
@@ -8,7 +8,7 @@ import pippy
 import torch
 import torch.distributed as dist
 from pippy.IR import pipe_split, pipeline
-from pippy.PipelineSchedule import PipelineScheduleGPipe
+from pippy.PipelineSchedule import ScheduleGPipe
 from pippy.PipelineStage import PipelineStage
 
 
@@ -68,7 +68,7 @@ def run_worker(args):
     )
 
     # Attach to a schedule
-    schedule = PipelineScheduleGPipe(stage, args.chunks)
+    schedule = ScheduleGPipe(stage, args.chunks)
 
     # Run
     if args.rank == 0:


### PR DESCRIPTION
fixes https://github.com/pytorch/PiPPy/issues/1010
Remove all `Pipeline` prefixes from schedule names (e.g. `PipelineScheduleGPipe` -> `ScheduleGPipe`)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1041

