### PR TITLE
Add base class for multi-stage schedules

### DIFF
--- a/pippy/ManualPipelineStage.py
+++ b/pippy/ManualPipelineStage.py
@@ -301,7 +301,6 @@ class ManualPipelineStage(PipelineStageBase):
             dist.P2POp(dist.isend, out, self.next_stage, self.group)
             for out in output_tuples
         ]
-        raise AssertionError("invalid fwd_outputs type, cannot send")
 
     def check_and_format_outputs(self, outputs: Any) -> List[torch.tensor]:
         # validate the output of the module is a type supported

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -218,7 +218,9 @@ class PipelineScheduleSingle(PipelineSchedule):
 
         # Split target into microbatches
         if target is not None:
-            targets_split = torch.tensor_split(target, self._n_microbatches)
+            targets_split = list(
+                torch.tensor_split(target, self._n_microbatches)
+            )
         else:
             targets_split = None
 
@@ -467,7 +469,9 @@ class PipelineScheduleMulti(PipelineSchedule):
 
         # Split target into microbatches
         if target is not None:
-            targets_split = torch.tensor_split(target, self._n_microbatches)
+            targets_split = list(
+                torch.tensor_split(target, self._n_microbatches)
+            )
         else:
             targets_split = None
 

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -663,15 +663,15 @@ class ScheduleInterleaved1F1B(PipelineScheduleMulti):
                 with record_function(f"1F1B {step}"):
                     ops = fwd_stage.get_fwd_recv_ops()
                     ops.extend(bwd_stage.get_bwd_recv_ops())
-
                     if ops:
                         dist.batch_isend_irecv(ops).pop().wait()
 
                     fwd_stage.forward_one_chunk(arg_mbs[mb_index])  # type: ignore[index]
-                    bwd_stage.backward_one_chunk()
-
                     ops = fwd_stage.get_fwd_send_ops()
+
+                    bwd_stage.backward_one_chunk()
                     ops.extend(bwd_stage.get_bwd_send_ops())
+
                     if ops:
                         dist.batch_isend_irecv(ops)
             # cooldown


### PR DESCRIPTION
Added class `PipelineScheduleMulti` as Base class for multi-stage schedules. And implement a common `step()` function for multi-stage schedules.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1055
* #1052
* #1051
* __->__ #1048

