### PR TITLE
Use stage index in PipelineStage's log prefix

### DIFF
--- a/pippy/PipelineStage.py
+++ b/pippy/PipelineStage.py
@@ -63,6 +63,8 @@ class PipelineStageBase(ABC):
         # Initialize has_backward to false; this will be set to true if loss
         # function is passed to pipeline schedule
         self.has_backward = False
+        # Log prefix
+        self.log_prefix = f"[Stage {self.stage_index}]"
 
     @property
     def has_backward(self) -> bool:
@@ -190,8 +192,8 @@ class PipelineStageBase(ABC):
             )
 
         except Exception as e:
-            exc_msg = f"""s
-            Stage {self.stage_index} failed to run forward:
+            exc_msg = f"""
+            {self.log_prefix} failed to run forward:
             args: {map_debug_info(composite_args)}
             kwargs: {map_debug_info(composite_kwargs)}
             """
@@ -218,7 +220,7 @@ class PipelineStageBase(ABC):
         )
 
         logger.debug(
-            f"[{self.stage_index}] Forwarded chunk {self.fwd_chunk_id}, outputs: {map_debug_info(output)}"
+            f"{self.log_prefix} Forwarded chunk {self.fwd_chunk_id}, outputs: {map_debug_info(output)}"
         )
         self.fwd_chunk_id += 1
         return output
@@ -260,9 +262,7 @@ class PipelineStageBase(ABC):
         self.grads_input = self.backward_maybe_with_nosync(
             bwd_kwargs, self.bwd_chunk_id
         )
-        logger.debug(
-            f"[{self.stage_index}] Backwarded chunk {self.bwd_chunk_id}"
-        )
+        logger.debug(f"{self.log_prefix} Backwarded chunk {self.bwd_chunk_id}")
         self.bwd_chunk_id += 1
 
 
@@ -376,7 +376,7 @@ class _PipelineStage(PipelineStageBase):
             for p in self.submod.parameters()
         )
         if has_meta_param:
-            logger.debug(f"[{self.stage_index}] Found meta parameters!")
+            logger.debug(f"{self.log_prefix} Found meta parameters!")
         else:
             self.submod.to(self.device)
 
@@ -438,7 +438,7 @@ class _PipelineStage(PipelineStageBase):
             # Create a receive buffer for this placeholder
             example_value = placeholder.meta["val"]
             logger.info(
-                f"[{self.stage_index}] "
+                f"{self.log_prefix} "
                 f"Creating recv buffer for input '{placeholder.name}' "
                 f": {example_value.shape}, {example_value.dtype}"
             )
@@ -464,7 +464,7 @@ class _PipelineStage(PipelineStageBase):
             args_recv_info.append(recv_info)
 
         logger.info(
-            f"[{self.stage_index}] "
+            f"{self.log_prefix} "
             f"Activation recv / args info: {args_recv_info}"
         )
         # `args` is a Tuple, hence we will return a Tuple[InputInfo]
@@ -511,7 +511,7 @@ class _PipelineStage(PipelineStageBase):
                 if dst_rank is not None:
                     dsts.append(dst_rank)
 
-        logger.info(f"[{self.stage_index}] " f"Send info: {act_send_info}")
+        logger.info(f"{self.log_prefix} " f"Send info: {act_send_info}")
         return act_send_info
 
     def _create_grad_recv_info(
@@ -536,7 +536,7 @@ class _PipelineStage(PipelineStageBase):
             output = output_vals[out_idx]
             example_value = output.meta["val"]
             logger.debug(
-                f"[{self.stage_index}] Creating grad recv buffer for output {output.name} "
+                f"{self.log_prefix} Creating grad recv buffer for output {output.name} "
                 f": {example_value.shape}, {example_value.dtype}"
             )
 
@@ -554,7 +554,7 @@ class _PipelineStage(PipelineStageBase):
         # Convert to tuple for convenience in get_ops and retrieve tensor
         grad_recv_info_tuple = tuple(grad_recv_info.values())
         logger.info(
-            f"[{self.stage_index}] " f"Grad recv info: {grad_recv_info_tuple}"
+            f"{self.log_prefix} " f"Grad recv info: {grad_recv_info_tuple}"
         )
         return grad_recv_info_tuple
 
@@ -577,9 +577,7 @@ class _PipelineStage(PipelineStageBase):
 
         map_aggregate(args_recv_info, map_recv_to_send)
 
-        logger.info(
-            f"[{self.stage_index}] " f"Grad send info: {grad_send_info}"
-        )
+        logger.info(f"{self.log_prefix} " f"Grad send info: {grad_send_info}")
         return grad_send_info
 
     def _get_recv_ops(
@@ -660,7 +658,7 @@ class _PipelineStage(PipelineStageBase):
                 if dst is None:
                     continue
                 logger.debug(
-                    f"[{self.stage_index}] "
+                    f"{self.log_prefix} "
                     f"Sending tensor to Stage {dst}: {out.size()}"
                 )
                 peer_rank = self.stage_index_to_group_rank[dst]
@@ -696,7 +694,7 @@ class _PipelineStage(PipelineStageBase):
         for grad, grad_recv_stage in zip(self.grads_input, self.grad_send_info):
             if isinstance(grad, torch.Tensor) and grad_recv_stage is not None:
                 logger.debug(
-                    f"[{self.stage_index}] "
+                    f"{self.log_prefix} "
                     f"Sending gradient to Stage {grad_recv_stage}: {grad.size()}"
                 )
                 peer_rank = self.stage_index_to_group_rank[grad_recv_stage]


### PR DESCRIPTION
Instead of using rank as the log prefix, clearer in case of Interleaved 1F1B.