### PR TITLE
Pipeline stages share fwd/bwd send/recv ops

### DIFF
--- a/pippy/ManualPipelineStage.py
+++ b/pippy/ManualPipelineStage.py
@@ -8,7 +8,12 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from pippy.PipelineStage import PipelineStageBase
+from pippy.PipelineStage import (
+    _make_tensor_from_meta,
+    PipelineStageBase,
+    RecvInfo,
+    RootArgPlaceholder,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -181,9 +186,7 @@ class ManualPipelineStage(PipelineStageBase):
         super().__init__(
             module, stage_id, num_stages, device, num_microbatches, group
         )
-        self.module = module.to(device)
-        self.is_first_stage = stage_id == 0
-        self.is_last_stage = stage_id == num_stages - 1
+        self.submod.to(self.device)
         # When we materialize the model partition on cuda, we call reset_parameters() if it is available
         # logger.info(f"input args {input_args=}")
         self.inputs: List[torch.tensor] = []
@@ -193,7 +196,7 @@ class ManualPipelineStage(PipelineStageBase):
             self.inputs = create_buffers(input_args, device)
 
         if output_args is None:
-            self.outputs = self.module(*self.inputs)
+            self.outputs = self.submod(*self.inputs)
             # create buffers for the output so that the data is in the correct
             # shape in order to use in p2p op (send)
             self.outputs = create_buffers(self.outputs, device)
@@ -220,36 +223,63 @@ class ManualPipelineStage(PipelineStageBase):
             (self.group_rank + 1) % self.group_size
         )
 
+        # Receive info during forward
+        # TODO: create args_recv_info lazily? (same needed for PipelineStage)
+        for chunk_id in range(self.chunks):
+            self.set_requires_grad[chunk_id] = False
+            if not self.is_first:
+                self.args_recv_info[chunk_id] = tuple(
+                    [
+                        RecvInfo(
+                            f"recv_for_{self.stage_index}_from_{self.stage_index - 1}",
+                            self.stage_index - 1,
+                            _make_tensor_from_meta(inp, self.device),
+                        )
+                        for inp in self.inputs
+                    ]
+                )
+            else:
+                self.args_recv_info[chunk_id] = tuple(
+                    [RootArgPlaceholder() for _ in self.inputs]
+                )
+
+        # Send info during forward for each activation
+        # only need the rank that is being sent to
+        self.act_send_info: Dict[int, List] = {}
+        for idx in range(len(self.outputs)):
+            if not self.is_last:
+                self.act_send_info[idx] = [self.stage_index + 1]
+            else:
+                self.act_send_info[idx] = []
+
         logger.debug(
             f"""
-            finished pipeline stage init, {self.stage_index=}, {self.is_first_stage=},
-            {self.is_last_stage=}, {self.num_stages=},
+            finished pipeline stage init, {self.stage_index=}, {self.is_first=},
+            {self.is_last=}, {self.num_stages=},
             inputs: {[inp.shape for inp in self.inputs]},
             output: {[output.shape for output in self.outputs]}
             """
         )
 
-    def _retrieve_recv_activations(
+    def _create_grad_recv_info(
         self,
-    ):
-        """
-        Retrieve the activations received for the current stage during forward.
-        """
-        # TODO: grad always gets set but later
-        # we can selectively choose which inputs require grads
-        for inp in self.inputs:
-            inp.requires_grad_(True)
-        return self.inputs
-
-    def _retrieve_recv_grads(
-        self,
-    ):
-        """
-        Retrieve the gradients received for the current stage during backward.
-        """
-        # TODO fix so we dont create a tensor
-        self.outputs_grad = [torch.empty_like(x) for x in self.outputs]
-        return self.outputs_grad
+        act_send_info: Dict,
+    ) -> Tuple[RecvInfo, ...]:
+        grad_recv_info: Tuple[RecvInfo, ...] = ()
+        if not self.is_last:
+            grad_recv_info = tuple(
+                [
+                    RecvInfo(
+                        f"recv_grad_for_{self.stage_index}_from_{dst_list[0]}",
+                        dst_list[0],
+                        _make_tensor_from_meta(self.outputs[idx], self.device),
+                    )
+                    for idx, dst_list in act_send_info.items()
+                ]
+            )
+        else:
+            grad_recv_info = tuple()
+        return grad_recv_info
 
     def init_p2p_neighbors(self):
         """
@@ -262,45 +292,26 @@ class ManualPipelineStage(PipelineStageBase):
         recv_tensor = torch.zeros(1, device="cuda")
         send_tensor = torch.ones(1, device="cuda")
         # forward
-        if not self.is_first_stage:
+        if not self.is_first:
             ops.append(
                 dist.P2POp(dist.irecv, recv_tensor, self.prev_stage, self.group)
             )
-        if not self.is_last_stage:
+        if not self.is_last:
             ops.append(
                 dist.P2POp(dist.isend, send_tensor, self.next_stage, self.group)
             )
 
         # backward
-        if not self.is_first_stage:
+        if not self.is_first:
             ops.append(
                 dist.P2POp(dist.isend, send_tensor, self.prev_stage, self.group)
             )
-        if not self.is_last_stage:
+        if not self.is_last:
             ops.append(
                 dist.P2POp(dist.irecv, recv_tensor, self.next_stage, self.group)
             )
 
         return True
-
-    def get_fwd_recv_ops(self) -> List[dist.P2POp]:
-        if self.is_first_stage:
-            return []
-        return [
-            dist.P2POp(dist.irecv, inp, self.prev_stage, self.group)
-            for inp in self.inputs
-        ]
-
-    def get_fwd_send_ops(self) -> List[dist.P2POp]:
-        output_tuples, flatten_input_tensors = self.fwd_cache[
-            self.fwd_chunk_id - 1
-        ]
-        if self.is_last_stage:
-            return []
-        return [
-            dist.P2POp(dist.isend, out, self.next_stage, self.group)
-            for out in output_tuples
-        ]
 
     def check_and_format_outputs(self, outputs: Any) -> List[torch.tensor]:
         # validate the output of the module is a type supported
@@ -318,22 +329,6 @@ class ManualPipelineStage(PipelineStageBase):
                 f"All elements in module output must be torch.tensor instances, but got {[type(x) for x in outputs]}"
             )
         return outputs
-
-    def get_bwd_recv_ops(self) -> List[dist.P2POp]:
-        if self.is_last_stage:
-            return []
-        return [
-            dist.P2POp(dist.irecv, grad, self.next_stage, self.group)
-            for grad in self.outputs_grad
-        ]
-
-    def get_bwd_send_ops(self) -> List[dist.P2POp]:
-        if self.is_first_stage:
-            return []
-        return [
-            dist.P2POp(dist.isend, inp.grad, self.prev_stage, self.group)
-            for inp in self.inputs
-        ]
 
 
 def validate_stage_shapes(pipeline_stages: List[ManualPipelineStage]):

--- a/pippy/ManualPipelineStage.py
+++ b/pippy/ManualPipelineStage.py
@@ -237,11 +237,11 @@ class ManualPipelineStage(PipelineStageBase):
                         )
                         for inp in self.inputs
                     ]
-                )
+                )  # type: ignore
             else:
                 self.args_recv_info[chunk_id] = tuple(
                     [RootArgPlaceholder() for _ in self.inputs]
-                )
+                )  # type: ignore
 
         # Send info during forward for each activation
         # only need the rank that is being sent to

--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -461,6 +461,11 @@ class PipelineScheduleMulti(PipelineSchedule):
         for stage in self._stages:
             stage.has_backward = self._has_backward
 
+        # TODO
+        self._should_compute_loss = (
+            lambda stage: stages[-1].is_last and self._loss_fn is not None
+        )
+
     def step(self, *args, target=None, losses: Optional[List] = None, **kwargs):
         # Clean per iteration
         for stage in self._stages:
@@ -509,14 +514,25 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
         else:
             kwarg_mbs = [{}] * self._n_microbatches
 
-        for s, stage in enumerate(self._stages):
+        # Internal loss container
+        internal_losses = []
+
+        for stage in self._stages:
             for i in range(self._n_microbatches):
-                with record_function(f"Stage {s} Forward"):
+                with record_function(f"Stage {stage.stage_index} Forward"):
                     ops = stage.get_fwd_recv_ops()
                     if ops:
                         dist.batch_isend_irecv(ops).pop().wait()
 
-                    stage.forward_one_chunk(arg_mbs[i], kwarg_mbs[i])
+                    output = stage.forward_one_chunk(arg_mbs[i], kwarg_mbs[i])
+
+                    if self._should_compute_loss(stage):
+                        target = target_mbs[i]  # type: ignore[index]
+                        loss = self._compute_loss(output, target)
+                        internal_losses.append(loss)
+                        logger.debug(
+                            f"[{stage.stage_index}] Loss of microbatch {i}: {loss}"
+                        )
 
                     ops = stage.get_fwd_send_ops()
                     if ops:
@@ -529,11 +545,21 @@ class ScheduleLoopedBFS(PipelineScheduleMulti):
                     if ops:
                         dist.batch_isend_irecv(ops).pop().wait()
 
-                    stage.backward_one_chunk()
+                    loss = (
+                        internal_losses[i] if len(internal_losses) > 0 else None
+                    )
+                    stage.backward_one_chunk(loss=loss)
 
                     ops = stage.get_bwd_send_ops()
                     if ops:
                         dist.batch_isend_irecv(ops)
+
+        # Return losses if there is a container passed in
+        if losses is not None:
+            # Clean external container first
+            losses.clear()
+            # Copy internal losses to external container
+            losses.extend(internal_losses)
 
 
 class ScheduleInterleaved1F1B(PipelineScheduleMulti):

--- a/test/test_pipeline_schedule_e2e.py
+++ b/test/test_pipeline_schedule_e2e.py
@@ -37,7 +37,6 @@ from pippy.PipelineSchedule import (
 from torch.distributed._tensor.device_mesh import init_device_mesh
 from torch.profiler import record_function
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -85,6 +84,13 @@ class MLP(nn.Module):
         self.wh3 = nn.Linear(hidden_dim, hidden_dim, bias=False)
         self.wo = nn.Linear(hidden_dim, out_dim, bias=False)
         self.gelu_act = nn.GELU(approximate="tanh")
+
+        # Apply Kaiming initialization
+        nn.init.kaiming_normal_(self.wi.weight)
+        nn.init.kaiming_normal_(self.wh1.weight)
+        nn.init.kaiming_normal_(self.wh3.weight)
+        nn.init.kaiming_normal_(self.wh3.weight)
+        nn.init.kaiming_normal_(self.wo.weight)
 
     def forward(self, x):
         a = self.wi(x)
@@ -148,7 +154,7 @@ def main(**kwargs):
     rank_print(f"kwargs are {kwargs}")
 
     input_dim = 900
-    hidden_dim = 8000
+    hidden_dim = 800
     output_dim = 900
 
     model = torch.nn.Sequential(
@@ -159,55 +165,73 @@ def main(**kwargs):
         modules=[model for i in range(world_size)]
     )
     microbatch_size = 8
-    global_batch_size = 128
+    global_batch_size = 64
     assert global_batch_size % microbatch_size == 0
     n_microbatches = int(global_batch_size / microbatch_size)
-    n_pp = world_size
 
-    x = torch.randn([microbatch_size, input_dim]).to("meta")
+    x = torch.randn([microbatch_size, input_dim]).to("cpu")
     unused = torch.ones((1, 1), device="meta")
     input_args = x
 
-    stage_model = ManualPipelineStage(
-        module_list[rank],
-        stage_id=rank,
-        num_stages=world_size,
-        device=device,
-        input_args=input_args,
-    )
-    stage_model.init_p2p_neighbors()
-
-    stage_model_looped = [
-        ManualPipelineStage(
+    if kwargs["stage_type"] == "manual":
+        stage_model = ManualPipelineStage(
             module_list[rank],
-            stage_id=(world_size * i) + rank,
-            num_stages=world_size * world_size,
+            stage_id=rank,
+            num_stages=world_size,
             device=device,
             input_args=input_args,
+            num_microbatches=n_microbatches,
         )
-        for i in range(world_size)
-    ]
+
+        stage_model_looped = [
+            ManualPipelineStage(
+                module_list[rank],
+                stage_id=(world_size * i) + rank,
+                num_stages=world_size * world_size,
+                device=device,
+                input_args=input_args,
+                num_microbatches=n_microbatches,
+            )
+            for i in range(world_size)
+        ]
+    elif kwargs["stage_type"] == "tracing":
+        pass
+        # TODO
+        # pipe = pipeline(model, n_microbatches, example_args=(input_args,))
+        # stage = PipelineStage(pipe, rank, device)
+
+    print(f"{[sm.stage_index for sm in stage_model_looped]}")
+
     x_cuda_empty = torch.empty_like(x, device="cuda")
 
     microbatches = []
     for i in range(n_microbatches):
         unused = torch.ones((1, 1), device="cuda")
-        microbatches.append(torch.randn_like(x_cuda_empty))
+        microbatches.append([torch.randn_like(x_cuda_empty)])
 
-    # barrier before
+    # Define a loss function
+    loss_fn = torch.nn.MSELoss(reduction="sum")
+    target_mbs = [
+        torch.randn(microbatch_size, output_dim, device=device)
+        for _ in range(n_microbatches)
+    ]
 
     _run_profiler = kwargs["profiler"]
     _trace_dir = kwargs["trace_dir"]
     for schedule in kwargs["schedules"]:
         logger.info(f"====== Rank {rank} running schedule {schedule} ======")
         if schedule == "gpipe":
-            pipeline = ScheduleGPipe(stage_model, n_microbatches)
+            my_schedule = ScheduleGPipe(stage_model, n_microbatches, loss_fn)
         elif schedule == "1f1b":
-            pipeline = Schedule1F1B(stage_model, n_microbatches)
+            my_schedule = Schedule1F1B(stage_model, n_microbatches, loss_fn)
         elif schedule == "looped_bfs":
-            pipeline = ScheduleLoopedBFS(stage_model_looped)
+            my_schedule = ScheduleLoopedBFS(
+                stage_model_looped, n_microbatches, loss_fn
+            )
         elif schedule == "interleaved_1f1b":
-            pipeline = ScheduleInterleaved1F1B(stage_model_looped)
+            my_schedule = ScheduleInterleaved1F1B(
+                stage_model_looped, n_microbatches, loss_fn
+            )
 
         if _run_profiler:
             logger.info(f"====== Rank {rank} profile ======")
@@ -216,7 +240,15 @@ def main(**kwargs):
             _run_profiler, _trace_dir, schedule, rank
         ) as _torch_profiler:
             with record_function(schedule):
-                pipeline.step(microbatches)
+                if rank == 0:
+                    my_schedule.step_microbatches(microbatches)
+                elif rank == world_size - 1:
+                    losses = []
+                    output = my_schedule.step_microbatches(
+                        target_mbs=target_mbs, losses=losses
+                    )
+                else:
+                    my_schedule.step_microbatches()
         logger.info(f"====== Rank {rank} finished {schedule} ======")
 
 
@@ -268,10 +300,11 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         choices=["gpipe", "1f1b", "looped_bfs", "interleaved_1f1b"],
-        # default=["gpipe"],
-        default=["interleaved_1f1b"],
+        default=["1f1b"],
+        # default=["looped_bfs"],
     )
     parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--stage_type", type=str, default="manual")
     args = parser.parse_args()
     kwargs = vars(args)
 


### PR DESCRIPTION
After changes in https://github.com/pytorch/PiPPy/pull/1024, `PipelineStage` and `ManualPipelineStage` shared the same data structures for managing the buffers and fwd cache. These changes build on top of that so that also the `get_fwd_recv_ops`, `get_fwd_send_ops`, `get_bwd_recv_ops`, `get_bwd_send_ops` are also shared.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1063
* #1060
* #1059
* __->__ #1058

