### PR TITLE
Refactor loss logic in schedules

### DIFF
--- a/pippy/PipelineSchedule.py
+++ b/pippy/PipelineSchedule.py
@@ -32,6 +32,7 @@ class PipelineSchedule(ABC):
         # To be filled by subclasses
         self._pipe_info: Optional[Pipe.PipeInfo] = None
 
+        # Holds the losses for each microbatch.
         self._internal_losses: List[torch.Tensor] = []
 
     def _maybe_compute_loss(self, stage, output, target_mbs, mb_index):
@@ -69,6 +70,8 @@ class PipelineSchedule(ABC):
             losses.clear()
             # Copy internal losses to external container
             losses.extend(self._internal_losses)
+
+        self._internal_losses.clear()
 
     @abstractmethod
     def step_microbatches(


### PR DESCRIPTION
Refactor the logic used to calculate and update loss into the base `PipelineSchedule` class methods.

Will update Interleaved1F1B in the following PR

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1063
* __->__ #1060
* #1059
* #1058

