### PR TITLE
pipeline() API accepting split_spec

### DIFF
--- a/examples/basic/example.py
+++ b/examples/basic/example.py
@@ -4,7 +4,7 @@
 
 import os
 import torch
-from pippy import pipeline, annotate_split_points, SplitPoint, ScheduleGPipe, PipelineStage
+from pippy import pipeline, SplitPoint, ScheduleGPipe, PipelineStage
 
 in_dim = 512
 layer_dims = [512, 1024, 256]
@@ -67,19 +67,16 @@ else:
 # Create the model
 mn = MyNetwork().to(device)
 
-annotate_split_points(
-    mn,
-    {
-        "layer0": SplitPoint.END,
-        "layer1": SplitPoint.END,
-    },
-)
+split_spec = {
+    "layer0": SplitPoint.END,
+    "layer1": SplitPoint.END,
+}
 
 batch_size = 32
 example_input = torch.randn(batch_size, in_dim, device=device)
 chunks = 4
 
-pipe = pipeline(mn, chunks, example_args=(example_input,))
+pipe = pipeline(mn, chunks, example_args=(example_input,), split_spec=split_spec)
 
 if rank == 0:
     print(" pipe ".center(80, "*"))

--- a/examples/basic/example_train.py
+++ b/examples/basic/example_train.py
@@ -4,7 +4,7 @@
 
 import os
 import torch
-from pippy import annotate_split_points, SplitPoint, ScheduleGPipe, PipelineStage
+from pippy import SplitPoint, ScheduleGPipe, PipelineStage
 
 in_dim = 512
 layer_dims = [512, 1024, 256]
@@ -67,20 +67,17 @@ else:
 # Create the model
 mn = MyNetwork().to(device)
 
-annotate_split_points(
-    mn,
-    {
-        "layer0": SplitPoint.END,
-        "layer1": SplitPoint.END,
-    },
-)
+split_spec = {
+    "layer0": SplitPoint.END,
+    "layer1": SplitPoint.END,
+}
 
 batch_size = 32
 example_input = torch.randn(batch_size, in_dim, device=device)
 chunks = 4
 
 from pippy import pipeline
-pipe = pipeline(mn, chunks, example_args=(example_input,))
+pipe = pipeline(mn, chunks, example_args=(example_input,), split_spec=split_spec)
 
 if rank == 0:
     print(" pipe ".center(80, "*"))


### PR DESCRIPTION
The PR allows the pipeline() API to directly accept a `split_spec` (a dict) rather than asking user to `annotate_split_point()` first.

Reason:
1. Making it a one-stop experience.
2. "Downplaying" the concept of _annotation_ by hiding it from the user.
3. The `pipeline()` API today accepts `split_policy`, so it would be best to put `split_spec` at the same place, making it an "either-or".

For examples of the new UI, please see the code change to example.py