### PR TITLE
Use non-strict mode by default

### DIFF
--- a/pippy/_IR.py
+++ b/pippy/_IR.py
@@ -1142,6 +1142,7 @@ class Pipe(QualnameMapMixin, torch.nn.Module):
             mod,
             example_args,
             example_kwargs,
+            strict=False,
         )
         return ep
 


### PR DESCRIPTION
`torch.export` has strict mode and non-strict mode. 
For difference, please read [Non-Strict Export](https://pytorch.org/docs/stable/export.html#non-strict-export).

This PR switches to non-strict mode by default. Improving tracing success rate (no Dynamo graph break).