### PR TITLE
Fix llama example split failed

### DIFF
--- a/examples/llama/pippy_llama.py
+++ b/examples/llama/pippy_llama.py
@@ -33,7 +33,7 @@ split_spec = {
 
 # Create a pipeline representation from the model
 mb_inputs = tokenizer(mb_prompts, return_tensors="pt", padding=True).to(device)
-pipe = pipeline(llama, mb_args=(mb_inputs["input_ids"],))
+pipe = pipeline(llama, mb_args=(mb_inputs["input_ids"],), split_spec=split_spec)
 
 # Create pipeline stage for each rank
 stage = pipe.build_stage(rank, device=device)


### PR DESCRIPTION
Missing `split_spec` in `pipeline` will cause error like:
```
RuntimeError: Pipeline group size 4 cannot be larger than number of stages 1
```