### PR TITLE
Update all hf examples to have dist.barrier

### DIFF
--- a/examples/huggingface/pippy_bert.py
+++ b/examples/huggingface/pippy_bert.py
@@ -73,6 +73,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_blenderbot.py
+++ b/examples/huggingface/pippy_blenderbot.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_camemBert.py
+++ b/examples/huggingface/pippy_camemBert.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_convBert.py
+++ b/examples/huggingface/pippy_convBert.py
@@ -75,6 +75,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_deberta.py
+++ b/examples/huggingface/pippy_deberta.py
@@ -74,6 +74,7 @@ def run(args):
         out = schedule.step()
 
     dist.barrier()
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_debertaV2.py
+++ b/examples/huggingface/pippy_debertaV2.py
@@ -78,6 +78,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_electra.py
+++ b/examples/huggingface/pippy_electra.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_fnet.py
+++ b/examples/huggingface/pippy_fnet.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_gpt2.py
+++ b/examples/huggingface/pippy_gpt2.py
@@ -77,6 +77,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_gptNeo.py
+++ b/examples/huggingface/pippy_gptNeo.py
@@ -72,6 +72,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_layoutLM.py
+++ b/examples/huggingface/pippy_layoutLM.py
@@ -73,6 +73,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_mbart.py
+++ b/examples/huggingface/pippy_mbart.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_megatronBert.py
+++ b/examples/huggingface/pippy_megatronBert.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_mobileBert.py
+++ b/examples/huggingface/pippy_mobileBert.py
@@ -70,6 +70,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_opt.py
+++ b/examples/huggingface/pippy_opt.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_trOCR.py
+++ b/examples/huggingface/pippy_trOCR.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_unet.py
+++ b/examples/huggingface/pippy_unet.py
@@ -65,6 +65,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 

--- a/examples/huggingface/pippy_xlnet.py
+++ b/examples/huggingface/pippy_xlnet.py
@@ -71,6 +71,7 @@ def run(args):
     else:
         out = schedule.step()
 
+    dist.barrier()
     dist.destroy_process_group()
     print(f"Rank {args.rank} completes")
 


### PR DESCRIPTION
Without having `dist.barrier()`, all of the HF examples wind up hanging since we're destroying the pg before all comms have completed in these small examples, leading to a hang. This PR adds `dist.barrier()` just before `dist.destroy_process_group()` to fix this. 